### PR TITLE
modify android build logic(gradle)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
     ext.caver_version = '1.5.3-rc.2'
-    ext.caver_android_version = '1.5.3-rc.2-android'
 }
 
 plugins {
@@ -140,7 +139,7 @@ allprojects {
 
     dependencies {
         if(isAndroidBuild) {
-            compile "com.klaytn.caver:core:$caver_android_version"
+            compile "com.klaytn.caver:core:$caver_version-android"
         } else {
             compile "com.klaytn.caver:core:$caver_version"
         }


### PR DESCRIPTION
## Proposed changes

This PR modify android build logic.
  - It determine build mode(common, android) "project.version.name" has -android.
  - remove android build version external variable, because In caver-java, both libraries are updated with the same version.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [ ] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-java-ext-kas/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-java-ext-kas)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
