### PR TITLE
modify timestamp test

### DIFF
--- a/src/test/java/xyz/groundx/caver_ext_kas/kas/tokenhistory/TokenHistoryQueryOptionsTest.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/kas/tokenhistory/TokenHistoryQueryOptionsTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.security.InvalidParameterException;
+import java.sql.Timestamp;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
@@ -28,6 +29,11 @@ import static org.junit.Assert.assertEquals;
 public class TokenHistoryQueryOptionsTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+
+    String getExpectedTimestampData(String date) {
+        long timestamp = Timestamp.valueOf(date).getTime();
+        return Long.toString(timestamp / 1000);
+    }
 
     @Test
     public void kindTest() {
@@ -82,9 +88,9 @@ public class TokenHistoryQueryOptionsTest {
 
     @Test
     public void rangeTimestampTest() {
-        String expectedTimeStamp = "1599145200";
         String dateFormat = "2020-09-04";
         String dateTimeFormat = "2020-09-04 00:00:00";
+        String expectedTimeStamp = getExpectedTimestampData(dateTimeFormat);
 
         TokenHistoryQueryOptions options = new TokenHistoryQueryOptions();
         options.setRange(dateFormat);
@@ -99,14 +105,14 @@ public class TokenHistoryQueryOptionsTest {
 
     @Test
     public void rangeFromToTest() {
-        String expectedString = "1599145200,1599231600";
-        String[] actualDataSet_timestamp = new String[] {"1599145200", "1599231600"};
+
         String[] actualDataSet_date = new String[] {"2020-09-04", "2020-09-05"};
         String[] actualDataSet_dateTime = new String[] {"2020-09-04 00:00:00", "2020-09-05 00:00:00"};
 
+        String expectedString = getExpectedTimestampData(actualDataSet_dateTime[0])+ "," + getExpectedTimestampData(actualDataSet_dateTime[1]);
+
         TokenHistoryQueryOptions options = new TokenHistoryQueryOptions();
-        options.setRange(actualDataSet_timestamp[0], actualDataSet_timestamp[1]);
-        assertEquals(expectedString, options.getRange());
+
 
         options.setRange(actualDataSet_date[0], actualDataSet_date[1]);
         assertEquals(expectedString, options.getRange());
@@ -114,13 +120,10 @@ public class TokenHistoryQueryOptionsTest {
         options.setRange(actualDataSet_dateTime[0], actualDataSet_dateTime[1]);
         assertEquals(expectedString, options.getRange());
 
-        options.setRange(actualDataSet_timestamp[0], actualDataSet_date[1]);
-        assertEquals(expectedString, options.getRange());
-
         options.setRange(actualDataSet_date[0], actualDataSet_dateTime[1]);
         assertEquals(expectedString, options.getRange());
 
-        options.setRange(actualDataSet_date[0], actualDataSet_dateTime[1]);
+        options.setRange(actualDataSet_dateTime[0], actualDataSet_date[1]);
         assertEquals(expectedString, options.getRange());
     }
 

--- a/src/test/java/xyz/groundx/caver_ext_kas/kas/utils/KASUtilsTest.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/kas/utils/KASUtilsTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.security.InvalidParameterException;
+import java.sql.Timestamp;
 
 import static org.junit.Assert.assertEquals;
 
@@ -28,17 +29,20 @@ public class KASUtilsTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
+    String getExpectedTimestampData(String date) {
+        long timestamp = Timestamp.valueOf(date).getTime();
+        return Long.toString(timestamp / 1000);
+    }
+
     @Test
     public void convertDateTest() {
-        String testDate1 = "2020-08-01 09:00:00";
+        String testDate1 = "2020-08-01 00:00:00";
         String testDate2 = "2020-08-01";
-        String testDate3 = "2020-08-01 09:00:00:111";
-        String testDate4 = "1596240000";
+        String testDate3 = "2020-08-01 00:00:00:111";
 
-        assertEquals("1596240000", KASUtils.convertDateToTimestamp(testDate1));
-        assertEquals("1596207600", KASUtils.convertDateToTimestamp(testDate2));
-        assertEquals("1596240000", KASUtils.convertDateToTimestamp(testDate3));
-        assertEquals("1596240000", KASUtils.convertDateToTimestamp(testDate4));
+        assertEquals(getExpectedTimestampData(testDate1), KASUtils.convertDateToTimestamp(testDate1));
+        assertEquals(getExpectedTimestampData(testDate1), KASUtils.convertDateToTimestamp(testDate2));
+        assertEquals(getExpectedTimestampData(testDate1), KASUtils.convertDateToTimestamp(testDate3));
     }
 
     @Test


### PR DESCRIPTION
## Proposed changes

This PR modify test case related to convert timestamp.
  - When converting a date string to a timestamp, the timestamp value changes according to the time zone.
  - so, modify to run test without being affected by time zone.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-java-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-java-ext-kas)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
