### PR TITLE
add "requestId" field in ExceptionDetail class.

### DIFF
--- a/src/main/java/xyz/groundx/caver_ext_kas/exception/ExceptionDetail.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/exception/ExceptionDetail.java
@@ -1,5 +1,8 @@
 package xyz.groundx.caver_ext_kas.exception;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ExceptionDetail {
     int code;
     String message = "";

--- a/src/main/java/xyz/groundx/caver_ext_kas/exception/ExceptionDetail.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/exception/ExceptionDetail.java
@@ -3,6 +3,7 @@ package xyz.groundx.caver_ext_kas.exception;
 public class ExceptionDetail {
     int code;
     String message = "";
+    String requestId = "";
 
     public ExceptionDetail() {
     }
@@ -13,5 +14,9 @@ public class ExceptionDetail {
 
     public String getMessage() {
         return message;
+    }
+
+    public String getRequestId() {
+        return requestId;
     }
 }

--- a/src/test/java/xyz/groundx/caver_ext_kas/exception/ExceptionDetailTest.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/exception/ExceptionDetailTest.java
@@ -1,0 +1,45 @@
+package xyz.groundx.caver_ext_kas.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+
+public class ExceptionDetailTest {
+    @Test
+    public void parse() throws IOException {
+        String test = "{\"code\":1061010,\"message\":\"data don't exist\",\"requestId\":\"6a1d4aba-fdc3-9a8a-bec7-c5de75abf9dd\"}";
+
+        ObjectMapper mapper = new ObjectMapper();
+        ExceptionDetail detail = mapper.readValue(test, ExceptionDetail.class);
+
+        assertEquals(1061010, detail.getCode());
+        assertEquals("data don't exist", detail.getMessage());
+        assertEquals("6a1d4aba-fdc3-9a8a-bec7-c5de75abf9dd", detail.getRequestId());
+    }
+
+    @Test
+    public void ignoreNotExistedField() throws IOException {
+        String test = "{\"code\":1061010,\"message\":\"data don't exist\"}";
+
+        ObjectMapper mapper = new ObjectMapper();
+        ExceptionDetail detail = mapper.readValue(test, ExceptionDetail.class);
+
+        assertEquals(1061010, detail.getCode());
+        assertEquals("data don't exist", detail.getMessage());
+    }
+
+    @Test
+    public void ignoreUnknownField() throws IOException {
+        String test = "{\"code\":1061010,\"message\":\"data don't exist\",\"requestId\":\"6a1d4aba-fdc3-9a8a-bec7-c5de75abf9dd\", \"unknown\": 1234}";
+
+        ObjectMapper mapper = new ObjectMapper();
+        ExceptionDetail detail = mapper.readValue(test, ExceptionDetail.class);
+
+        assertEquals(1061010, detail.getCode());
+        assertEquals("data don't exist", detail.getMessage());
+        assertEquals("6a1d4aba-fdc3-9a8a-bec7-c5de75abf9dd", detail.getRequestId());
+    }
+}


### PR DESCRIPTION
## Proposed changes

This PR added following contents
  - add "requestId" field in ExceptionDetail class.
  - When parsing error message, ignore unknown or not existed field 

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-java-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-java-ext-kas)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
