### PR TITLE
add overloading functions which has tokenId with BigInteger type in TH API.

### DIFF
--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/tokenhistory/TokenHistory.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/tokenhistory/TokenHistory.java
@@ -17,6 +17,7 @@
 package xyz.groundx.caver_ext_kas.kas.tokenhistory;
 
 import com.squareup.okhttp.Call;
+import org.web3j.utils.Numeric;
 import xyz.groundx.caver_ext_kas.kas.utils.KASUtils;
 import xyz.groundx.caver_ext_kas.rest_client.io.swagger.client.ApiCallback;
 import xyz.groundx.caver_ext_kas.rest_client.io.swagger.client.ApiClient;
@@ -24,6 +25,7 @@ import xyz.groundx.caver_ext_kas.rest_client.io.swagger.client.ApiException;
 import xyz.groundx.caver_ext_kas.rest_client.io.swagger.client.api.tokenhistory.api.*;
 import xyz.groundx.caver_ext_kas.rest_client.io.swagger.client.api.tokenhistory.model.*;
 
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 
@@ -653,6 +655,20 @@ public class TokenHistory {
      * @return MtToken
      * @throws ApiException
      */
+    public MtToken getMT(String mtAddress, String ownerAddress, BigInteger tokenID) throws ApiException {
+        return getMT(mtAddress, ownerAddress, Numeric.toHexStringWithPrefix(tokenID));
+
+    }
+
+    /**
+     * Retrieve a specific MT(Multiple Token) corresponding to the given address and tokenID.<br>
+     * GET /v2/contract/mt/{mt-address}/owner/{owner-address}/token/{token-id}
+     * @param mtAddress The MT contract address.
+     * @param ownerAddress The owner address.
+     * @param tokenID The token id.
+     * @return MtToken
+     * @throws ApiException
+     */
     public MtToken getMT(String mtAddress, String ownerAddress, String tokenID) throws ApiException {
         return this.tokenApi.getMtTokensByContractAddressAndOwnerAddressAndTokenId(chainId, mtAddress, ownerAddress, tokenID);
     }
@@ -667,8 +683,36 @@ public class TokenHistory {
      * @return Call
      * @throws ApiException
      */
+    public Call getMTAsync(String mtAddress, String ownerAddress, BigInteger tokenID, ApiCallback<MtToken> callback) throws ApiException {
+        return getMTAsync(mtAddress, ownerAddress, Numeric.toHexStringWithPrefix(tokenID), callback);
+    }
+
+    /**
+     * Retrieve a specific MT(Multiple Token) corresponding to the given address and tokenID asynchronously.<br>
+     * GET /v2/contract/mt/{mt-address}/owner/{owner-address}/token/{token-id}
+     * @param mtAddress The MT contract address.
+     * @param ownerAddress The owner address.
+     * @param tokenID The token id.
+     * @param callback The callback function to handle response.
+     * @return Call
+     * @throws ApiException
+     */
     public Call getMTAsync(String mtAddress, String ownerAddress, String tokenID, ApiCallback<MtToken> callback) throws ApiException {
         return this.tokenApi.getMtTokensByContractAddressAndOwnerAddressAndTokenIdAsync(chainId, mtAddress, ownerAddress, tokenID, callback);
+    }
+
+    /**
+     * Retrieve a specific MT(Multiple Token) owner corresponding to the given tokenID.<br>
+     * It will send a request without filter options.<br>
+     * If you want to execute this function with search options(size, cursor), use getMTOwnerByTokenId(String, TokenHistoryQueryOptions).<br>
+     * GET /v2/contract/mt/{mt-address}/token/{token-id}
+     * @param mtAddress The MT contract address.
+     * @param tokenId The token id.
+     * @return PageableMtTokens
+     * @throws ApiException
+     */
+    public PageableMtTokens getMTOwnerListByTokenId(String mtAddress, BigInteger tokenId) throws ApiException {
+        return getMTOwnerListByTokenId(mtAddress, Numeric.toHexStringWithPrefix(tokenId));
     }
 
     /**
@@ -696,8 +740,37 @@ public class TokenHistory {
      * @return PageableMtTokens
      * @throws ApiException
      */
+    public PageableMtTokens getMTOwnerListByTokenId(String mtAddress, BigInteger tokenId, TokenHistoryQueryOptions options) throws ApiException {
+        return getMTOwnerListByTokenId(mtAddress, Numeric.toHexStringWithPrefix(tokenId), options);
+    }
+
+    /**
+     * Retrieve a specific MT(Multiple Token) owner corresponding to the given tokenID.<br>
+     * You can set a search options(size, cursor) by using TokenHistoryQueryOptions.<br>
+     * GET /v2/contract/mt/{mt-address}/token/{token-id}
+     * @param mtAddress The MT contract address.
+     * @param tokenId The token id.
+     * @param options Filters required when retrieving data. `size`, `cursor`.
+     * @return PageableMtTokens
+     * @throws ApiException
+     */
     public PageableMtTokens getMTOwnerListByTokenId(String mtAddress, String tokenId, TokenHistoryQueryOptions options) throws ApiException {
         return this.tokenApi.getMtTokensByContractAddressAndTokenId(chainId, mtAddress, tokenId, options.getCursor(), options.getSize());
+    }
+
+    /**
+     * Retrieve a specific MT(Multiple Token) owner corresponding to the given tokenID asynchronously.<br>
+     * It will send a request without filter options.<br>
+     * If you want to execute this function with search options(size, cursor), use getMTOwnerByTokenId(String, TokenHistoryQueryOptions).<br>
+     * GET /v2/contract/mt/{mt-address}/token/{token-id}
+     * @param mtAddress The MT contract address.
+     * @param tokenId The token id.
+     * @param callback The callback function to handle response.
+     * @return Call
+     * @throws ApiException
+     */
+    public Call getMTOwnerListByTokenIdAsync(String mtAddress, BigInteger tokenId, ApiCallback<PageableMtTokens> callback) throws ApiException {
+        return getMTOwnerListByTokenIdAsync(mtAddress, Numeric.toHexStringWithPrefix(tokenId), callback);
     }
 
     /**
@@ -714,6 +787,21 @@ public class TokenHistory {
     public Call getMTOwnerListByTokenIdAsync(String mtAddress, String tokenId, ApiCallback<PageableMtTokens> callback) throws ApiException {
         TokenHistoryQueryOptions options = new TokenHistoryQueryOptions();
         return getMTOwnerListByTokenIdAsync(mtAddress, tokenId, options, callback);
+    }
+
+    /**
+     * Retrieve a specific MT(Multiple Token) owner corresponding to the given tokenID asynchronously.<br>
+     * You can set a search options(size, cursor) by using TokenHistoryQueryOptions.<br>
+     * GET /v2/contract/mt/{mt-address}/token/{token-id}
+     * @param mtAddress The MT contract address.
+     * @param tokenId The token id.
+     * @param options Filters required when retrieving data. `size`, `cursor`.
+     * @param callback The callback function to handle response.
+     * @return Call
+     * @throws ApiException
+     */
+    public Call getMTOwnerListByTokenIdAsync(String mtAddress, BigInteger tokenId, TokenHistoryQueryOptions options, ApiCallback<PageableMtTokens> callback) throws ApiException {
+        return getMTOwnerListByTokenIdAsync(mtAddress, Numeric.toHexStringWithPrefix(tokenId), options, callback);
     }
 
     /**

--- a/src/test/java/xyz/groundx/caver_ext_kas/kas/tokenhistory/TokenHistoryAPITest.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/kas/tokenhistory/TokenHistoryAPITest.java
@@ -979,9 +979,48 @@ public class TokenHistoryAPITest {
     }
 
     @Ignore
+    public void getMTWithNumber() throws ApiException {
+        MtToken token = caver.kas.tokenHistory.getMT(mtAddress, account, BigInteger.valueOf(1));
+        assertNotNull(token);
+    }
+
+    @Ignore
     public void getMT() throws ApiException {
         MtToken token = caver.kas.tokenHistory.getMT(mtAddress, account, "0x1");
         assertNotNull(token);
+    }
+
+    @Ignore
+    public void getMTAsyncWithNumber() throws ApiException, ExecutionException, InterruptedException {
+        CompletableFuture<MtToken> future = new CompletableFuture<>();
+
+        Call result = caver.kas.tokenHistory.getMTAsync(mtAddress, account, BigInteger.valueOf(1), new ApiCallback<MtToken>() {
+            @Override
+            public void onFailure(ApiException e, int statusCode, Map<String, List<String>> responseHeaders) {
+                future.completeExceptionally(e);
+            }
+
+            @Override
+            public void onSuccess(MtToken result, int statusCode, Map<String, List<String>> responseHeaders) {
+                future.complete(result);
+            }
+
+            @Override
+            public void onUploadProgress(long bytesWritten, long contentLength, boolean done) {
+
+            }
+
+            @Override
+            public void onDownloadProgress(long bytesRead, long contentLength, boolean done) {
+
+            }
+        });
+
+        if(future.isCompletedExceptionally()) {
+            fail();
+        } else {
+            assertNotNull(future.get());
+        }
     }
 
     @Ignore
@@ -1024,6 +1063,12 @@ public class TokenHistoryAPITest {
     }
 
     @Ignore
+    public void getMTOwnerListByTokenIdWithNumber() throws ApiException {
+        PageableMtTokens pageableMtTokens = caver.kas.tokenHistory.getMTOwnerListByTokenId(mtAddress, BigInteger.valueOf(1));
+        assertNotNull(pageableMtTokens);
+    }
+
+    @Ignore
     public void getMTOwnerListByTokenIdWithSize() throws ApiException {
         TokenHistoryQueryOptions options = new TokenHistoryQueryOptions();
         options.setSize(1L);
@@ -1048,6 +1093,39 @@ public class TokenHistoryAPITest {
         CompletableFuture<PageableMtTokens> future = new CompletableFuture<>();
 
         Call result = caver.kas.tokenHistory.getMTOwnerListByTokenIdAsync(mtAddress, "0x1", new ApiCallback<PageableMtTokens>() {
+            @Override
+            public void onFailure(ApiException e, int statusCode, Map<String, List<String>> responseHeaders) {
+                future.completeExceptionally(e);
+            }
+
+            @Override
+            public void onSuccess(PageableMtTokens result, int statusCode, Map<String, List<String>> responseHeaders) {
+                future.complete(result);
+            }
+
+            @Override
+            public void onUploadProgress(long bytesWritten, long contentLength, boolean done) {
+
+            }
+
+            @Override
+            public void onDownloadProgress(long bytesRead, long contentLength, boolean done) {
+
+            }
+        });
+
+        if(future.isCompletedExceptionally()) {
+            fail();
+        } else {
+            assertNotNull(future.get());
+        }
+    }
+
+    @Ignore
+    public void getMTOwnerListByTokenIdAsyncWithNumber() throws ApiException, ExecutionException, InterruptedException {
+        CompletableFuture<PageableMtTokens> future = new CompletableFuture<>();
+
+        Call result = caver.kas.tokenHistory.getMTOwnerListByTokenIdAsync(mtAddress, BigInteger.valueOf(1), new ApiCallback<PageableMtTokens>() {
             @Override
             public void onFailure(ApiException e, int statusCode, Map<String, List<String>> responseHeaders) {
                 future.completeExceptionally(e);


### PR DESCRIPTION
## Proposed changes

This PR added overloading functions which has tokenId with BigInteger type in TH API.
 - getMT()
 - getMTOwnerListByTokenId()

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-java-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-java-ext-kas)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
