### PR TITLE
Modified logic to check whether the account type is AccountKeyWeightedMultiSig

### DIFF
--- a/src/main/java/xyz/groundx/caver_ext_kas/wallet/KASWallet.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/wallet/KASWallet.java
@@ -318,7 +318,7 @@ public class KASWallet implements IWallet {
 
     private boolean isWeightedMultiSigType(AbstractFeeDelegatedTransaction fdTransaction, String address) throws IOException {
         AccountKey res = fdTransaction.getKlaytnCall().getAccountKey(address).send();
-        if(res == null) {
+        if(res == null  || res.getResult() == null) {
             return true;
         }
         AccountKey.AccountKeyData accountKeyData = res.getResult();

--- a/src/main/java/xyz/groundx/caver_ext_kas/wallet/KASWallet.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/wallet/KASWallet.java
@@ -288,7 +288,7 @@ public class KASWallet implements IWallet {
 
     private boolean isWeightedMultiSigType(AbstractTransaction transaction, String address) throws IOException {
         AccountKey res = transaction.getKlaytnCall().getAccountKey(address).send();
-        if(res == null) {
+        if(res == null || res.getResult() == null) {
             return false;
         }
 


### PR DESCRIPTION
## Proposed changes

This PR modified isWeightedMultiSigType(). 
   - handle case that if the response of getAccountKey() has null.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-java-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-java-ext-kas)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
