### PR TITLE
Using a maven-publish plugin instead to bintray plugin to upload library.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,8 @@ jobs:
       - run:
           name: "publish"
           command: |
-              ./gradlew clean build -x test  --debug
-              ./gradlew bintrayUpload --stacktrace --debug
+            ./graldew clean publish --stacktrace --debug
+            ./graldew closeAndReleaseRepository --stacktrace --debug
       - store_artifacts:
           path: ./build
       - notify-failure
@@ -100,8 +100,8 @@ jobs:
       - run:
           name: "build and publish for android"
           command: |
-              ./gradlew clean build -x test  --debug
-              ./gradlew bintrayUpload --stacktrace --debug
+            ./graldew clean publish --stacktrace --debug
+            ./graldew closeAndReleaseRepository --stacktrace --debug
       - store_artifacts:
           path: ./build
       - notify-failure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,8 @@ jobs:
       - run:
           name: "publish"
           command: |
-            ./graldew clean publish --stacktrace --debug
-            ./graldew closeAndReleaseRepository --stacktrace --debug
+            ./gradlew clean publish --stacktrace --debug
+            ./gradlew closeAndReleaseRepository --stacktrace --debug
       - store_artifacts:
           path: ./build
       - notify-failure
@@ -100,8 +100,8 @@ jobs:
       - run:
           name: "build and publish for android"
           command: |
-            ./graldew clean publish --stacktrace --debug
-            ./graldew closeAndReleaseRepository --stacktrace --debug
+            ./gradlew clean publish --stacktrace --debug
+            ./gradlew closeAndReleaseRepository --stacktrace --debug
       - store_artifacts:
           path: ./build
       - notify-failure

--- a/build.gradle
+++ b/build.gradle
@@ -9,11 +9,14 @@ plugins {
     id 'signing'
     id 'idea'
 
-    id "com.jfrog.bintray" version "1.8.5"
+    id 'io.codearte.nexus-staging' version '0.30.0'
 }
 
+//It should only be applied on the ROOT project in a build.
+apply plugin: 'io.codearte.nexus-staging'
+
 allprojects {
-    version '1.1.1'
+    version '1.1.1-rc.3'
     group 'xyz.groundx.caver'
     description 'An extension library of caver-java for using KAS (Klaytn API Service).'
 
@@ -23,7 +26,6 @@ allprojects {
     apply plugin: 'java'
     apply plugin: 'signing'
     apply plugin: 'maven-publish'
-    apply plugin: 'com.jfrog.bintray'
 
 
     repositories {
@@ -59,10 +61,8 @@ allprojects {
     }
 
     ext {
-        bintrayUser = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
-        bintrayKey = project.hasProperty('bintrayKey') ? project.property('bintrayKey') : System.getenv('BINTRAY_KEY')
-        bintrayGpgPassphrase = project.hasProperty('bintrayGpgPassphrase') ? project.property('bintrayGpgPassphrase') : System.getenv('BINTRAY_GPG_PASSPHRASE')
-
+        ossrhUsername = project.hasProperty('ossrhUsername') ? project.property('ossrhUsername') : System.getenv('OSSRH_USERNAME')
+        ossrhPassword = project.hasProperty('ossrhPassword') ? project.property('ossrhPassword') : System.getenv('OSSRH_PASSWORD')
         isAndroidBuild = project.version.endsWith("-android")
     }
 
@@ -100,52 +100,22 @@ allprojects {
                 }
             }
         }
-    }
-
-    bintray {
-        user = bintrayUser
-        key = bintrayKey
-        publications = ['mavenJava']
-        publish = true
-        pkg {
-            desc = project.description
-            repo = 'maven'
-            name = 'caver-java-ext-kas'
-            licenses = ['Apache-2.0']
-            issueTrackerUrl = 'https://github.com/ground-x/caver-java-ext-kas/issues'
-            vcsUrl = 'https://github.com/ground-x/caver-java-ext-kas.git'
-            websiteUrl = 'https://www.klaytnapi.com'
-            publicDownloadNumbers = true
-
-            version {
-                name = project.version
-                desc = project.description
-                gpg {
-                    sign = true
-                    passphrase = bintrayGpgPassphrase
-                }
-                mavenCentralSync {
-                    sync = false
+        repositories {
+            maven {
+                url "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+                credentials {
+                    username ossrhUsername
+                    password ossrhPassword
                 }
             }
         }
     }
 
-    task release {
-        dependsOn 'build'
-        dependsOn 'bintrayUpload'
-
-        doLast {
-            if (!bintrayUser || !bintrayKey || !bintrayGpgPassphrase) {
-                throw new InvalidUserDataException("Required parameters missing:  'bintrayUser', 'bintrayKey', 'bintrayGpgPassphrase'")
-            }
-
-            logger.lifecycle(" - bintrayUser={}", bintrayUser)
-            logger.lifecycle(" - bintrayKey={}", bintrayKey ? "provided" : "not_provided")
-            logger.lifecycle(" - bintrayGpgPassphrase={}", bintrayGpgPassphrase ? "provided" : "not_provided")
-        }
-
-        tasks.findByName('bintrayUpload').mustRunAfter 'build'
+    signing {
+        def signingKey = findProperty("signingKey")
+        def signingPassword = findProperty("signingPassword")
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign publishing.publications.mavenJava
     }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ allprojects {
     ext {
         ossrhUsername = project.hasProperty('ossrhUsername') ? project.property('ossrhUsername') : System.getenv('OSSRH_USERNAME')
         ossrhPassword = project.hasProperty('ossrhPassword') ? project.property('ossrhPassword') : System.getenv('OSSRH_PASSWORD')
+        ossrhSigningKey_base64 = project.hasProperty('signingKey')? project.property('signingKey') : System.getenv('ORG_GRADLE_PROJECT_signingKey')
+        ossrhSigningPassword = project.hasProperty('signingKey')? project.property('signingPassword') : System.getenv('ORG_GRADLE_PROJECT_signingPassword')
+
         isAndroidBuild = project.version.endsWith("-android")
     }
 
@@ -112,8 +115,12 @@ allprojects {
     }
 
     signing {
-        def signingKey = findProperty("signingKey")
-        def signingPassword = findProperty("signingPassword")
+        def signingPassword = ossrhSigningPassword
+
+        def signingKey_base64 = ossrhSigningKey_base64
+        def signingKey = (signingKey_base64 == null? null:
+                new String(Base64.getMimeDecoder().decode(signingKey_base64.toString()), "utf-8"))
+        
         useInMemoryPgpKeys(signingKey, signingPassword)
         sign publishing.publications.mavenJava
     }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 apply plugin: 'io.codearte.nexus-staging'
 
 allprojects {
-    version '1.1.1-rc.3'
+    version '1.1.1'
     group 'xyz.groundx.caver'
     description 'An extension library of caver-java for using KAS (Klaytn API Service).'
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
     id 'signing'
     id 'idea'
 
-    id 'io.codearte.nexus-staging' version '0.30.0'
+    id 'io.codearte.nexus-staging' version "0.30.0"
 }
 
 //It should only be applied on the ROOT project in a build.


### PR DESCRIPTION
## Proposed changes

This PR used a maven-publish plugin instead to bintray plugin to upload library.
  - deleted a bintray code.
  - added a OSSRH Gradle Nexus Staging Plugin to automated release.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-java-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-java-ext-kas)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
