### PR TITLE
Modified KAS API test

### DIFF
--- a/src/test/java/xyz/groundx/caver_ext_kas/kas/kip17/KIP17Test.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/kas/kip17/KIP17Test.java
@@ -522,7 +522,7 @@ public class KIP17Test {
     }
 
     @Test
-    public void approveAll() throws ApiException, IOException, TransactionException {
+    public void approveAll() throws ApiException, InterruptedException {
         String from = caver.kas.wallet.createAccount().getAddress();
         String to = caver.kas.wallet.createAccount().getAddress();
 

--- a/src/test/java/xyz/groundx/caver_ext_kas/kas/kip17/KIP17Test.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/kas/kip17/KIP17Test.java
@@ -20,6 +20,7 @@ import com.klaytn.caver.methods.response.TransactionReceipt;
 import com.klaytn.caver.transaction.response.PollingTransactionReceiptProcessor;
 import com.klaytn.caver.transaction.response.TransactionReceiptProcessor;
 import com.squareup.okhttp.Call;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -80,14 +81,14 @@ public class KIP17Test {
 
         caver.kas.kip17.getApiClient().setDebugging(true);
         prepareKIP17Contract();
-
-
     }
 
+
     @Test
-    public void deploy() throws ApiException {
+    public void deploy() throws ApiException, InterruptedException {
         Kip17TransactionStatusResponse response = caver.kas.kip17.deploy("KIP17", "KCT17", "kk-" + new Date().getTime());
         assertNotNull(response);
+        Thread.sleep(5000);
     }
 
     @Test
@@ -119,6 +120,8 @@ public class KIP17Test {
             fail();
         } else {
             assertNotNull(future.get());
+            Thread.sleep(5000);
+
         }
     }
 
@@ -225,14 +228,15 @@ public class KIP17Test {
     }
 
     @Test
-    public void mint() throws ApiException {
+    public void mint() throws ApiException, InterruptedException {
         String to = account;
         String id = Numeric.toHexStringWithPrefix(BigInteger.valueOf(new Date().getTime()));
         String uri = "https://test.com";
 
         Kip17TransactionStatusResponse response = caver.kas.kip17.mint(testContractAlias, to, id, uri);
-
         assertNotNull(response);
+
+        Thread.sleep(5000);
     }
 
     @Test
@@ -268,6 +272,7 @@ public class KIP17Test {
             fail();
         } else {
             assertNotNull(future.get());
+            Thread.sleep(5000);
         }
     }
 
@@ -372,13 +377,14 @@ public class KIP17Test {
     }
 
     @Test
-    public void transfer() throws ApiException, IOException, TransactionException {
+    public void transfer() throws ApiException, IOException, TransactionException, InterruptedException {
         BigInteger tokenId = BigInteger.valueOf(new Date().getTime());
         mintToken(testContractAlias, account, tokenId);
         String to = caver.kas.wallet.createAccount().getAddress();
 
         Kip17TransactionStatusResponse response = caver.kas.kip17.transfer(testContractAlias, account, account, to, tokenId);
         assertNotNull(response);
+        Thread.sleep(5000);
     }
 
     @Test
@@ -415,16 +421,18 @@ public class KIP17Test {
             fail();
         } else {
             assertNotNull(future.get());
+            Thread.sleep(5000);
         }
     }
 
     @Test
-    public void burn() throws ApiException, IOException, TransactionException {
+    public void burn() throws ApiException, IOException, TransactionException, InterruptedException {
         BigInteger id = BigInteger.valueOf(new Date().getTime());
         mintToken(testContractAlias, account, id);
 
         Kip17TransactionStatusResponse burnResponse = caver.kas.kip17.burn(testContractAlias, account, id);
         assertNotNull(burnResponse);
+        Thread.sleep(5000);
     }
 
     @Test
@@ -460,16 +468,19 @@ public class KIP17Test {
             fail();
         } else {
             assertNotNull(future.get());
+            Thread.sleep(5000);
         }
     }
 
     @Test
-    public void approve() throws ApiException {
+    public void approve() throws ApiException, InterruptedException {
         String from = account;
         String to = caver.kas.wallet.createAccount().getAddress();
 
         Kip17TokenListResponse res = caver.kas.kip17.getTokenList(testContractAlias);
         Kip17TransactionStatusResponse response = caver.kas.kip17.approve(testContractAlias, from, to, res.getItems().get(0).getTokenId());
+        assertNotNull(response);
+        Thread.sleep(5000);
     }
 
     @Test
@@ -506,6 +517,7 @@ public class KIP17Test {
             fail();
         } else {
             assertNotNull(completableFuture.get());
+            Thread.sleep(5000);
         }
     }
 
@@ -516,6 +528,7 @@ public class KIP17Test {
 
         Kip17TransactionStatusResponse response = caver.kas.kip17.approveAll(testContractAlias, from, to, true);
         assertNotNull(response);
+        Thread.sleep(5000);
     }
 
     @Test
@@ -551,6 +564,7 @@ public class KIP17Test {
             fail();
         } else {
             assertNotNull(future.get());
+            Thread.sleep(5000);
         }
     }
 


### PR DESCRIPTION
## Proposed changes

This PR modified KAS API test
  - Added an enough delay to submit transaction.
  - Modify Wallet API test case
    - requestAccountUpdateToAccountKeyLegacy
    - requestAccountUpdateToAccountKeyLegacyAsync
    - requestFDAccountUpdatePaidByGlobalFeePayerToLegacyType
    - requestFDAccountUpdatePaidByGlobalFeePayerToLegacyTypeAsync
    - requestFDAccountUpdatePaidByUserToLegacyType
    - requestFDAccountUpdatePaidByUserToLegacyTypeAsync

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-java-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-java-ext-kas)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
