### PR TITLE
Added account migration feature

### DIFF
--- a/src/main/java/xyz/groundx/caver_ext_kas/CaverExtKAS.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/CaverExtKAS.java
@@ -24,8 +24,6 @@ import org.web3j.protocol.http.HttpService;
 import xyz.groundx.caver_ext_kas.kas.KAS;
 import xyz.groundx.caver_ext_kas.wallet.KASWallet;
 
-import java.util.Objects;
-
 /**
  * Representing wrapping class that can use Klaytn API Service
  */
@@ -152,7 +150,7 @@ public class CaverExtKAS extends Caver {
         httpService.addHeader("Authorization", Credentials.basic(accessKeyId, secretAccessKey));
         httpService.addHeader("x-chain-id", chainId);
         this.rpc = new RPC(httpService);
-        if (!Objects.isNull(this.kas.wallet)) {
+        if (this.kas.wallet != null) {
             this.kas.wallet.setRPC(this.rpc);
         }
     }
@@ -242,7 +240,8 @@ public class CaverExtKAS extends Caver {
      * @param url An URL to request Wallet API.
      */
     public void initWalletAPI(String chainId, String accessKeyId, String secretAccessKey, String url) {
-        kas.initWalletAPI(chainId, accessKeyId, secretAccessKey, url, this.rpc);
+        kas.initWalletAPI(chainId, accessKeyId, secretAccessKey, url);
+        kas.wallet.setRPC(this.rpc);
         setWallet(new KASWallet(this.kas.wallet));
     }
 

--- a/src/main/java/xyz/groundx/caver_ext_kas/CaverExtKAS.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/CaverExtKAS.java
@@ -24,6 +24,8 @@ import org.web3j.protocol.http.HttpService;
 import xyz.groundx.caver_ext_kas.kas.KAS;
 import xyz.groundx.caver_ext_kas.wallet.KASWallet;
 
+import java.util.Objects;
+
 /**
  * Representing wrapping class that can use Klaytn API Service
  */
@@ -150,6 +152,9 @@ public class CaverExtKAS extends Caver {
         httpService.addHeader("Authorization", Credentials.basic(accessKeyId, secretAccessKey));
         httpService.addHeader("x-chain-id", chainId);
         this.rpc = new RPC(httpService);
+        if (!Objects.isNull(this.kas.wallet)) {
+            this.kas.wallet.setRPC(this.rpc);
+        }
     }
 
     /**
@@ -237,7 +242,7 @@ public class CaverExtKAS extends Caver {
      * @param url An URL to request Wallet API.
      */
     public void initWalletAPI(String chainId, String accessKeyId, String secretAccessKey, String url) {
-        kas.initWalletAPI(chainId, accessKeyId, secretAccessKey, url);
+        kas.initWalletAPI(chainId, accessKeyId, secretAccessKey, url, this.rpc);
         setWallet(new KASWallet(this.kas.wallet));
     }
 

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/KAS.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/KAS.java
@@ -16,6 +16,7 @@
 
 package xyz.groundx.caver_ext_kas.kas;
 
+import com.klaytn.caver.rpc.RPC;
 import xyz.groundx.caver_ext_kas.kas.anchor.Anchor;
 import xyz.groundx.caver_ext_kas.kas.kip17.KIP17;
 import xyz.groundx.caver_ext_kas.kas.tokenhistory.TokenHistory;
@@ -75,14 +76,15 @@ public class KAS {
      * @param accessKeyId The access key provided by KAS console.
      * @param secretAccessKey The secret key provided by KAS console.
      * @param url An URL to request Wallet API.
+     * @param rpc The RPC for using Node API.
      */
-    public KAS initWalletAPI(String chainId, String accessKeyId, String secretAccessKey, String url) {
+    public KAS initWalletAPI(String chainId, String accessKeyId, String secretAccessKey, String url, RPC rpc) {
         ApiClient apiClient = new ApiClient();
         apiClient.setBasePath(url);
         apiClient.setUsername(accessKeyId);
         apiClient.setPassword(secretAccessKey);
 
-        setWallet(new Wallet(chainId, apiClient));
+        setWallet(new Wallet(chainId, apiClient, rpc));
         return this;
     }
 

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/KAS.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/KAS.java
@@ -76,15 +76,14 @@ public class KAS {
      * @param accessKeyId The access key provided by KAS console.
      * @param secretAccessKey The secret key provided by KAS console.
      * @param url An URL to request Wallet API.
-     * @param rpc The RPC for using Node API.
      */
-    public KAS initWalletAPI(String chainId, String accessKeyId, String secretAccessKey, String url, RPC rpc) {
+    public KAS initWalletAPI(String chainId, String accessKeyId, String secretAccessKey, String url) {
         ApiClient apiClient = new ApiClient();
         apiClient.setBasePath(url);
         apiClient.setUsername(accessKeyId);
         apiClient.setPassword(secretAccessKey);
 
-        setWallet(new Wallet(chainId, apiClient, rpc));
+        setWallet(new Wallet(chainId, apiClient));
         return this;
     }
 

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/Wallet.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/Wallet.java
@@ -120,16 +120,8 @@ public class Wallet {
      * <pre>Example :
      * {@code
      * ArrayList<MigrationAccount> accountsToBeMigrated = new ArrayList<>();
-     * accountsToBeMigrated.add(new MigrationAccount.Builder()
-     *         .setAddress("0x{address}")
-     *         .setMigrationAccountKey(new SinglePrivateKey("0x{privateKey}"))
-     *         .build()
-     * );
-     * accountsToBeMigrated.add(new MigrationAccount.Builder()
-     *         .setAddress("0x{address}")
-     *         .setMigrationAccountKey(new SinglePrivateKey("0x{privateKey}"))
-     *         .build()
-     * );
+     * accountsToBeMigrated.add(new MigrationAccount("0x{address}", "0x{privateKey}"));
+     * accountsToBeMigrated.add(new MigrationAccount("0x{address}", "0x1" "0x{privateKey}"));
      *
      * RegistrationStatusResponse response = caver.kas.wallet.migrateAccounts(accountsToBeMigrated);
      * }</pre>
@@ -170,14 +162,6 @@ public class Wallet {
             MigrationAccount migrationAccount = accounts.get(i);
             Key key = createdKeys.get(i);
 
-            if (migrationAccount.getNonce() == "0x") {
-                String nonce = this.rpc.klay.getTransactionCount(
-                        migrationAccount.getAddress(),
-                        DefaultBlockParameterName.PENDING
-                ).send().getResult();
-                migrationAccount.setNonce(nonce);
-            }
-
             FeeDelegatedAccountUpdate tx = new FeeDelegatedAccountUpdate.Builder()
                     .setChainId(BigInteger.valueOf(Integer.parseInt(chainId)))
                     .setFrom(migrationAccount.getAddress())
@@ -190,6 +174,7 @@ public class Wallet {
                     )
                     .setGas(BigInteger.valueOf(1000000))
                     .setGasPrice(gasPrice)
+                    .setKlaytnCall(this.rpc.getKlay())
                     .build();
 
             AbstractKeyring keyring = createKeyringFromMigrationAccount(migrationAccount);

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/Wallet.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/Wallet.java
@@ -121,7 +121,7 @@ public class Wallet {
      * {@code
      * ArrayList<MigrationAccount> accountsToBeMigrated = new ArrayList<>();
      * accountsToBeMigrated.add(new MigrationAccount("0x{address}", "0x{privateKey}"));
-     * accountsToBeMigrated.add(new MigrationAccount("0x{address}", "0x1" "0x{privateKey}"));
+     * accountsToBeMigrated.add(new MigrationAccount("0x{address}", "0x{privateKey}", "0x{nonce}"));
      *
      * RegistrationStatusResponse response = caver.kas.wallet.migrateAccounts(accountsToBeMigrated);
      * }</pre>

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/Wallet.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/Wallet.java
@@ -2037,7 +2037,7 @@ public class Wallet {
      * @return boolean
      */
     private boolean validateMigrationAccount(MigrationAccount migrationAccount) {
-        if(migrationAccount.getAddress() == "") {
+        if(migrationAccount.getAddress().isEmpty()) {
             System.out.println("ERROR: Address of migrationAccount must not be empty.");
             return false;
         }
@@ -2048,12 +2048,10 @@ public class Wallet {
             return false;
         }
 
-        String keyClassName = migrationAccountKey.getClass().getSimpleName();
-
         if(
-                keyClassName.equals(SinglePrivateKey.class.getSimpleName()) == false
-                        && keyClassName.equals(MultisigPrivateKeys.class.getSimpleName()) == false
-                        && keyClassName.equals(RoleBasedPrivateKeys.class.getSimpleName()) == false
+                migrationAccountKey instanceof SinglePrivateKey == false
+                        && migrationAccountKey instanceof MultisigPrivateKeys == false
+                        && migrationAccountKey instanceof RoleBasedPrivateKeys == false
         ) {
             System.out.println(
                     "MigrationAccountKey of Migration Account must be one of following class " +
@@ -2066,25 +2064,24 @@ public class Wallet {
 
     /**
      * Create an AbstractKeyring from a given migrationAccount
-     * @param migrationAccount
+     * @param migrationAccount account to be migrated to KAS Wallet
      * @return AbstractKeyring
      * @throws IllegalArgumentException
      */
     private AbstractKeyring createKeyringFromMigrationAccount(MigrationAccount migrationAccount) throws IllegalArgumentException {
         MigrationAccountKey<?> migrationAccountKey = migrationAccount.getMigrationAccountKey();
-        String keyClassName = migrationAccountKey.getClass().getSimpleName();
 
-        if(SinglePrivateKey.class.getSimpleName().equals(keyClassName)) {
+        if(migrationAccountKey instanceof SinglePrivateKey) {
             return KeyringFactory.create(
                     migrationAccount.getAddress(),
                     ((SinglePrivateKey) migrationAccountKey).getKey()
             );
-        } else if(MultisigPrivateKeys.class.getSimpleName().equals(keyClassName)) {
+        } else if(migrationAccountKey instanceof MultisigPrivateKeys) {
             return KeyringFactory.create(
                     migrationAccount.getAddress(),
                     ((MultisigPrivateKeys) migrationAccountKey).getKey()
             );
-        } else if(RoleBasedPrivateKeys.class.getSimpleName().equals(keyClassName)) {
+        } else if(migrationAccountKey instanceof RoleBasedPrivateKeys) {
             return KeyringFactory.create(
                     migrationAccount.getAddress(),
                     ((RoleBasedPrivateKeys) migrationAccountKey).getKey()

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/Wallet.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/Wallet.java
@@ -2031,9 +2031,8 @@ public class Wallet {
     /**
      * Validate whether given migrationAccount is valid or not.
      * @param migrationAccount An account to be migrated to KAS Wallet
-     * @throws IllegalArgumentException
      */
-    private void validateMigrationAccount(MigrationAccount migrationAccount) throws IllegalArgumentException {
+    private void validateMigrationAccount(MigrationAccount migrationAccount) {
         if(migrationAccount.getAddress().isEmpty()) {
             throw new IllegalArgumentException("Address of migrationAccount must not be empty.");
         }
@@ -2059,9 +2058,8 @@ public class Wallet {
      * Create an AbstractKeyring from a given migrationAccount
      * @param migrationAccount account to be migrated to KAS Wallet
      * @return AbstractKeyring
-     * @throws IllegalArgumentException
      */
-    private AbstractKeyring createKeyringFromMigrationAccount(MigrationAccount migrationAccount) throws IllegalArgumentException {
+    private AbstractKeyring createKeyringFromMigrationAccount(MigrationAccount migrationAccount) {
         MigrationAccountKey<?> migrationAccountKey = migrationAccount.getMigrationAccountKey();
 
         if(migrationAccountKey instanceof SinglePrivateKey) {

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/Wallet.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/Wallet.java
@@ -132,7 +132,7 @@ public class Wallet {
      * @throws IOException
      * @throws NoSuchFieldException
      */
-    public RegistrationStatusResponse migrateAccounts(List<MigrationAccount> accounts) throws ApiException, IOException, IllegalArgumentException, NoSuchFieldException {
+    public RegistrationStatusResponse migrateAccounts(List<MigrationAccount> accounts) throws ApiException, IOException, NoSuchFieldException {
         if (this.rpc == null) {
             throw new NoSuchFieldException("Before using migrateAccounts, initNodeAPI must  be called first.");
         }
@@ -140,16 +140,13 @@ public class Wallet {
         if (this.rpc.getWeb3jService() instanceof HttpService) {
             String url = ((HttpService) this.rpc.getWeb3jService()).getUrl();
             if (!url.contains("klaytnapi")) {
-                System.out.println("WARN: Endpoint URL of Node API is " + url + " which is not klaytnapi.");
-                System.out.println("WARN: You should initialize Node API with working endpoint url before calling migrateAccounts.");
+                throw new RuntimeException("You should initialize Node API with working endpoint url before calling migrateAccounts.");
             }
         }
 
         // Need to validate whether given list of migration accounts is valid or not.
         for (int i=0; i<accounts.size(); i++) {
-            if (validateMigrationAccount(accounts.get(i)) == false) {
-                throw new IllegalArgumentException("Given MigrationAccount is not valid.");
-            };
+            validateMigrationAccount(accounts.get(i));
         }
 
         AccountRegistrationRequest request = new AccountRegistrationRequest();
@@ -2034,18 +2031,16 @@ public class Wallet {
     /**
      * Validate whether given migrationAccount is valid or not.
      * @param migrationAccount An account to be migrated to KAS Wallet
-     * @return boolean
+     * @throws IllegalArgumentException
      */
-    private boolean validateMigrationAccount(MigrationAccount migrationAccount) {
+    private void validateMigrationAccount(MigrationAccount migrationAccount) throws IllegalArgumentException {
         if(migrationAccount.getAddress().isEmpty()) {
-            System.out.println("ERROR: Address of migrationAccount must not be empty.");
-            return false;
+            throw new IllegalArgumentException("Address of migrationAccount must not be empty.");
         }
 
         MigrationAccountKey<?> migrationAccountKey = migrationAccount.getMigrationAccountKey();
         if(migrationAccountKey == null) {
-            System.out.println("ERROR: MigrationAccountKey of migrationAccount must not be empty.");
-            return false;
+            throw new IllegalArgumentException("MigrationAccountKey of migrationAccount must not be empty.");
         }
 
         if(
@@ -2053,13 +2048,11 @@ public class Wallet {
                         && migrationAccountKey instanceof MultisigPrivateKeys == false
                         && migrationAccountKey instanceof RoleBasedPrivateKeys == false
         ) {
-            System.out.println(
+            throw new IllegalArgumentException(
                     "MigrationAccountKey of Migration Account must be one of following class " +
                     "[SinglePrivateKey, MultisigPrivateKeys, RoleBasedPrivateKeys]."
             );
-            return false;
         }
-        return true;
     }
 
     /**

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccount.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccount.java
@@ -16,62 +16,55 @@
 
 package xyz.groundx.caver_ext_kas.kas.wallet.migration;
 
-import org.web3j.utils.Numeric;
-
-import java.math.BigInteger;
+import java.util.List;
 
 /**
  * Representing a MigrationAccount which is used migrate external Klaytn account to KAS Wallet.
  */
 public class MigrationAccount {
+    /**
+     * An address of the account to be migrated.
+     */
     private String address;
-    private String nonce = "0x";
-    private MigrationAccountKey<?> migrationAccountKey = null;
-
-    public MigrationAccount(MigrationAccount.Builder builder) {
-        this(builder.address,
-                builder.nonce,
-                builder.migrationAccountKey
-        );
-    }
-
-    public MigrationAccount(String address, String nonce, MigrationAccountKey<?> migrationAccountKey) {
-        setAddress(address);
-        setNonce(nonce);
-        setMigrationAccountKey(migrationAccountKey);
-    }
 
     /**
-     * Represents a MigrationAccount class builder.
+     * The nonce value of the account to be migrated in hexadecimal format.
      */
-    public static class Builder {
-        private String address;
-        private String nonce = "0x";
-        private MigrationAccountKey<?> migrationAccountKey = null;
+    private String nonce = "0x";
 
-        public MigrationAccount.Builder setAddress(String address) {
-            this.address = address;
-            return this;
-        }
+    /**
+     * A instance of MigrationAccountKey representing various type of private key.
+     */
+    private MigrationAccountKey<?> migrationAccountKey = null;
 
-        public MigrationAccount.Builder setNonce(String nonce) {
-            this.nonce = nonce;
-            return this;
-        }
+    public MigrationAccount(String address, String singlePrivateKey) {
+        this(address, "0x", singlePrivateKey);
+    }
 
-        public MigrationAccount.Builder setNonce(BigInteger nonce) {
-            this.nonce = Numeric.toHexStringWithPrefix(nonce);
-            return this;
-        }
+    public MigrationAccount(String address, String[] multisigPrivateKeys) {
+        this(address, "0x", multisigPrivateKeys);
+    }
 
-        public MigrationAccount.Builder setMigrationAccountKey(MigrationAccountKey<?> migrationAccountKey) {
-            this.migrationAccountKey = migrationAccountKey;
-            return this;
-        }
+    public MigrationAccount(String address, List<String[]> roleBasedPrivateKeys) {
+        this(address, "0x", roleBasedPrivateKeys);
+    }
 
-        public MigrationAccount build() {
-            return new MigrationAccount(this);
-        }
+    public MigrationAccount(String address, String nonce, String singlePrivateKey) {
+        setAddress(address);
+        setNonce(nonce);
+        setMigrationAccountKey(new SinglePrivateKey(singlePrivateKey));
+    }
+
+    public MigrationAccount(String address, String nonce, String[] multisigPrivateKeys) {
+        setAddress(address);
+        setNonce(nonce);
+        setMigrationAccountKey(new MultisigPrivateKeys(multisigPrivateKeys));
+    }
+
+    public MigrationAccount(String address, String nonce, List<String[]> roleBasedPrivateKeys) {
+        setAddress(address);
+        setNonce(nonce);
+        setMigrationAccountKey(new RoleBasedPrivateKeys(roleBasedPrivateKeys));
     }
 
     public String getAddress() {

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccount.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccount.java
@@ -16,6 +16,9 @@
 
 package xyz.groundx.caver_ext_kas.kas.wallet.migration;
 
+import org.web3j.utils.Numeric;
+
+import java.math.BigInteger;
 import java.util.List;
 
 /**
@@ -29,6 +32,8 @@ public class MigrationAccount {
 
     /**
      * The nonce value of the account to be migrated in hexadecimal format.
+     * Notice: Even if you set the nonce value much higher than the original account has, the API response will be Ok.
+     * Therefore, it is recommended not to directly specify the nonce value.
      */
     private String nonce = "0x";
 
@@ -54,8 +59,19 @@ public class MigrationAccount {
         setMigrationAccountKey(new SinglePrivateKey(singlePrivateKey));
         setNonce(nonce);
     }
+    public MigrationAccount(String address, String singlePrivateKey, BigInteger nonce) {
+        setAddress(address);
+        setMigrationAccountKey(new SinglePrivateKey(singlePrivateKey));
+        setNonce(nonce);
+    }
 
     public MigrationAccount(String address, String[] multisigPrivateKeys, String nonce) {
+        setAddress(address);
+        setMigrationAccountKey(new MultisigPrivateKeys(multisigPrivateKeys));
+        setNonce(nonce);
+    }
+
+    public MigrationAccount(String address, String[] multisigPrivateKeys, BigInteger nonce) {
         setAddress(address);
         setMigrationAccountKey(new MultisigPrivateKeys(multisigPrivateKeys));
         setNonce(nonce);
@@ -67,6 +83,13 @@ public class MigrationAccount {
         setNonce(nonce);
     }
 
+    public MigrationAccount(String address, List<String[]> roleBasedPrivateKeys, BigInteger nonce) {
+        setAddress(address);
+        setMigrationAccountKey(new RoleBasedPrivateKeys(roleBasedPrivateKeys));
+        setNonce(nonce);
+    }
+
+
     public String getAddress() {
         return this.address;
     }
@@ -77,6 +100,10 @@ public class MigrationAccount {
 
     public String getNonce() {
         return this.nonce;
+    }
+
+    public void setNonce(BigInteger nonce) {
+        setNonce(Numeric.toHexStringWithPrefix(nonce));
     }
 
     public void setNonce(String nonce) {

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccount.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccount.java
@@ -31,8 +31,8 @@ public class MigrationAccount {
     private String address;
 
     /**
-     * The nonce value of the account to be migrated in hexadecimal format.
-     * Notice: Even if you set the nonce value much higher than the original account has, the API response will be Ok.
+     * The nonce value of the account to be migrated in hexadecimal format. <br>
+     * Notice: Even if you set the nonce value much higher than the original account has, the API response will be Ok. <br>
      * Therefore, it is recommended not to directly specify the nonce value.
      */
     private String nonce = "0x";
@@ -141,30 +141,58 @@ public class MigrationAccount {
         setNonce(nonce);
     }
 
+    /**
+     * Get an address of account to be migrated.
+     * @return String An address of account to be migrated.
+     */
     public String getAddress() {
         return this.address;
     }
 
+    /**
+     * Set an address of account to be migrated.
+     * @param address An address of account to be migrated.
+     */
     public void setAddress(String address) {
         this.address = address;
     }
 
+    /**
+     * Get a nonce value in hexadecimal format.
+     * @return String A nonce value of account to be migrated
+     */
     public String getNonce() {
         return this.nonce;
     }
 
+    /**
+     * Set a nonce value.
+     * @param nonce A nonce value of account to be migrated
+     */
     public void setNonce(BigInteger nonce) {
         setNonce(Numeric.toHexStringWithPrefix(nonce));
     }
 
+    /**
+     * Set a nonce value in hexadecimal format.
+     * @param nonce A nonce value in hexadecimal format of account to be migrated.
+     */
     public void setNonce(String nonce) {
         this.nonce = nonce;
     }
 
+    /**
+     * Get a MigrationKey of account to be migrated.
+     * @return {@code MigrationAccountKey<?>} The migrationAccountKey of account to be migrated.
+     */
     public MigrationAccountKey<?> getMigrationAccountKey() {
         return this.migrationAccountKey;
     }
 
+    /**
+     * Set a MigrationKey of account to be migrated.
+     * @param key The migrationAccountKey of account to be migrated.
+     */
     public void setMigrationAccountKey(MigrationAccountKey<?> key) {
         this.migrationAccountKey = key;
     }

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccount.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccount.java
@@ -42,53 +42,104 @@ public class MigrationAccount {
      */
     private MigrationAccountKey<?> migrationAccountKey = null;
 
+    /**
+     * Create a MigrationAccount instance.
+     * @param address An address of account to be migrated.
+     * @param singlePrivateKey A private of account to be migrated.
+     */
     public MigrationAccount(String address, String singlePrivateKey) {
         this(address, singlePrivateKey, "0x");
     }
 
+    /**
+     * Create a MigrationAccount instance.
+     * @param address An address of account to be migrated.
+     * @param multisigPrivateKeys Multiple private keys of account to be migrated.
+     */
     public MigrationAccount(String address, String[] multisigPrivateKeys) {
         this(address, multisigPrivateKeys, "0x");
     }
 
+    /**
+     * Create a MigrationAccount instance.
+     * @param address An address of account to be migrated.
+     * @param roleBasedPrivateKeys A list of multiple private keys of account to be migrated.
+     */
     public MigrationAccount(String address, List<String[]> roleBasedPrivateKeys) {
         this(address, roleBasedPrivateKeys, "0x");
     }
 
+    /**
+     * Create a MigrationAccount instance.
+     * @param address An address of account to be migrated.
+     * @param singlePrivateKey A private of account to be migrated.
+     * @param nonce A nonce value in hexadecimal format of account to be migrated.
+     */
     public MigrationAccount(String address, String singlePrivateKey, String nonce) {
         setAddress(address);
         setMigrationAccountKey(new SinglePrivateKey(singlePrivateKey));
         setNonce(nonce);
     }
+
+    /**
+     * Create a MigrationAccount instance.
+     * @param address An address of account to be migrated.
+     * @param singlePrivateKey A private of account to be migrated.
+     * @param nonce A nonce value of the BigInteger type of account to be migrated
+     */
     public MigrationAccount(String address, String singlePrivateKey, BigInteger nonce) {
         setAddress(address);
         setMigrationAccountKey(new SinglePrivateKey(singlePrivateKey));
         setNonce(nonce);
     }
 
+    /**
+     * Create a MigrationAccount instance.
+     * @param address An address of account to be migrated.
+     * @param multisigPrivateKeys Multiple private keys of account to be migrated.
+     * @param nonce A nonce value in hexadecimal format of account to be migrated.
+     */
     public MigrationAccount(String address, String[] multisigPrivateKeys, String nonce) {
         setAddress(address);
         setMigrationAccountKey(new MultisigPrivateKeys(multisigPrivateKeys));
         setNonce(nonce);
     }
 
+    /**
+     * Create a MigrationAccount instance.
+     * @param address An address of account to be migrated.
+     * @param multisigPrivateKeys Multiple private keys of account to be migrated.
+     * @param nonce A nonce value of the BigInteger type of account to be migrated
+     */
     public MigrationAccount(String address, String[] multisigPrivateKeys, BigInteger nonce) {
         setAddress(address);
         setMigrationAccountKey(new MultisigPrivateKeys(multisigPrivateKeys));
         setNonce(nonce);
     }
 
+    /**
+     * Create a MigrationAccount instance.
+     * @param address An address of account to be migrated.
+     * @param roleBasedPrivateKeys A list of multiple private keys of account to be migrated.
+     * @param nonce A nonce value in hexadecimal format of account to be migrated.
+     */
     public MigrationAccount(String address, List<String[]> roleBasedPrivateKeys, String nonce) {
         setAddress(address);
         setMigrationAccountKey(new RoleBasedPrivateKeys(roleBasedPrivateKeys));
         setNonce(nonce);
     }
 
+    /**
+     * Create a MigrationAccount instance.
+     * @param address An address of account to be migrated.
+     * @param roleBasedPrivateKeys A list of multiple private keys of account to be migrated.
+     * @param nonce A nonce value of the BigInteger type of account to be migrated
+     */
     public MigrationAccount(String address, List<String[]> roleBasedPrivateKeys, BigInteger nonce) {
         setAddress(address);
         setMigrationAccountKey(new RoleBasedPrivateKeys(roleBasedPrivateKeys));
         setNonce(nonce);
     }
-
 
     public String getAddress() {
         return this.address;

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccount.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccount.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 The caver-java-ext-kas Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.groundx.caver_ext_kas.kas.wallet.migration;
+
+import org.web3j.utils.Numeric;
+
+import java.math.BigInteger;
+
+/**
+ * Representing a MigrationAccount which is used migrate external Klaytn account to KAS Wallet.
+ */
+public class MigrationAccount {
+    private String address;
+    private String nonce = "0x";
+    private MigrationAccountKey<?> migrationAccountKey = null;
+
+    public MigrationAccount(MigrationAccount.Builder builder) {
+        this(builder.address,
+                builder.nonce,
+                builder.migrationAccountKey
+        );
+    }
+
+    public MigrationAccount(String address, String nonce, MigrationAccountKey<?> migrationAccountKey) {
+        setAddress(address);
+        setNonce(nonce);
+        setMigrationAccountKey(migrationAccountKey);
+    }
+
+    /**
+     * Represents a MigrationAccount class builder.
+     */
+    public static class Builder {
+        private String address;
+        private String nonce = "0x";
+        private MigrationAccountKey<?> migrationAccountKey = null;
+
+        public MigrationAccount.Builder setAddress(String address) {
+            this.address = address;
+            return this;
+        }
+
+        public MigrationAccount.Builder setNonce(String nonce) {
+            this.nonce = nonce;
+            return this;
+        }
+
+        public MigrationAccount.Builder setNonce(BigInteger nonce) {
+            this.nonce = Numeric.toHexStringWithPrefix(nonce);
+            return this;
+        }
+
+        public MigrationAccount.Builder setMigrationAccountKey(MigrationAccountKey<?> migrationAccountKey) {
+            this.migrationAccountKey = migrationAccountKey;
+            return this;
+        }
+
+        public MigrationAccount build() {
+            return new MigrationAccount(this);
+        }
+    }
+
+    public String getAddress() {
+        return this.address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getNonce() {
+        return this.nonce;
+    }
+
+    public void setNonce(String nonce) {
+        this.nonce = nonce;
+    }
+
+    public MigrationAccountKey<?> getMigrationAccountKey() {
+        return this.migrationAccountKey;
+    }
+
+    public void setMigrationAccountKey(MigrationAccountKey<?> key) {
+        this.migrationAccountKey = key;
+    }
+}

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccount.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccount.java
@@ -38,33 +38,33 @@ public class MigrationAccount {
     private MigrationAccountKey<?> migrationAccountKey = null;
 
     public MigrationAccount(String address, String singlePrivateKey) {
-        this(address, "0x", singlePrivateKey);
+        this(address, singlePrivateKey, "0x");
     }
 
     public MigrationAccount(String address, String[] multisigPrivateKeys) {
-        this(address, "0x", multisigPrivateKeys);
+        this(address, multisigPrivateKeys, "0x");
     }
 
     public MigrationAccount(String address, List<String[]> roleBasedPrivateKeys) {
-        this(address, "0x", roleBasedPrivateKeys);
+        this(address, roleBasedPrivateKeys, "0x");
     }
 
-    public MigrationAccount(String address, String nonce, String singlePrivateKey) {
+    public MigrationAccount(String address, String singlePrivateKey, String nonce) {
         setAddress(address);
-        setNonce(nonce);
         setMigrationAccountKey(new SinglePrivateKey(singlePrivateKey));
+        setNonce(nonce);
     }
 
-    public MigrationAccount(String address, String nonce, String[] multisigPrivateKeys) {
+    public MigrationAccount(String address, String[] multisigPrivateKeys, String nonce) {
         setAddress(address);
-        setNonce(nonce);
         setMigrationAccountKey(new MultisigPrivateKeys(multisigPrivateKeys));
+        setNonce(nonce);
     }
 
-    public MigrationAccount(String address, String nonce, List<String[]> roleBasedPrivateKeys) {
+    public MigrationAccount(String address, List<String[]> roleBasedPrivateKeys, String nonce) {
         setAddress(address);
-        setNonce(nonce);
         setMigrationAccountKey(new RoleBasedPrivateKeys(roleBasedPrivateKeys));
+        setNonce(nonce);
     }
 
     public String getAddress() {

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccountKey.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccountKey.java
@@ -19,8 +19,12 @@ package xyz.groundx.caver_ext_kas.kas.wallet.migration;
 /**
  * MigrationAccountKey represents a type of private key.
  * @param <T> Basic data types that make up the various types of Migration Account Key types.<br>
- * e.g. <pre>{@code String, String[], List<String[]>}</pre>
+ * e.g. {@code String, String[], List<String[]>}
  */
 public abstract class MigrationAccountKey<T> {
+    /**
+     * Get private key of account to be migrated to KAS Wallet.
+     * @return T Generic type which can be one of {@code String, String[], List<String[]>}.
+     */
     abstract public T getKey();
 }

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccountKey.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccountKey.java
@@ -18,7 +18,8 @@ package xyz.groundx.caver_ext_kas.kas.wallet.migration;
 
 /**
  * MigrationAccountKey represents a type of private key.
- * @param <T> Basic data types that make up the various types of Migration Account Key types, e.g. String, String[], List<String[]>
+ * @param <T> Basic data types that make up the various types of Migration Account Key types.<br>
+ * e.g. <pre>{@code String, String[], List<String[]>}</pre>
  */
 public abstract class MigrationAccountKey<T> {
     abstract public T getKey();

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccountKey.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccountKey.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 The caver-java-ext-kas Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.groundx.caver_ext_kas.kas.wallet.migration;
+
+/**
+ * MigrationAccountKey represents a type of private key.
+ * @param <T> The object type extending MigrationAccountKey
+ */
+public abstract class MigrationAccountKey<T> {
+    abstract public T getKey();
+}

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccountKey.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MigrationAccountKey.java
@@ -18,7 +18,7 @@ package xyz.groundx.caver_ext_kas.kas.wallet.migration;
 
 /**
  * MigrationAccountKey represents a type of private key.
- * @param <T> The object type extending MigrationAccountKey
+ * @param <T> Basic data types that make up the various types of Migration Account Key types, e.g. String, String[], List<String[]>
  */
 public abstract class MigrationAccountKey<T> {
     abstract public T getKey();

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MultisigPrivateKeys.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MultisigPrivateKeys.java
@@ -17,11 +17,18 @@
 package xyz.groundx.caver_ext_kas.kas.wallet.migration;
 
 /**
- * MutisigPrivateKeys presents a set of private keys of weighted multisig key account type.
+ * MutisigPrivateKeys presents multiple private keys of weighted multisig key account type.
  */
 public class MultisigPrivateKeys extends MigrationAccountKey<String[]> {
+    /**
+     * Multiple private keys of external Klaytn account to be migrated to KAS Wallet.
+     */
     String[] key;
 
+    /**
+     * Create a MultisigPrivateKeys instance which will be used as member variable of MigrationAccount.
+     * @param multipleKey Multiple private keys of external Klaytn account to be migrated to KAS Wallet.
+     */
     public MultisigPrivateKeys(String[] multipleKey) {
         this.key = multipleKey;
     }

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MultisigPrivateKeys.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MultisigPrivateKeys.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 The caver-java-ext-kas Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.groundx.caver_ext_kas.kas.wallet.migration;
+
+/**
+ * MutisigPrivateKeys presents a set of private keys of weighted multisig key account type.
+ */
+public class MultisigPrivateKeys extends MigrationAccountKey<String[]> {
+    String[] key;
+
+    public MultisigPrivateKeys(String[] multipleKey) {
+        this.key = multipleKey;
+    }
+
+    @Override
+    public String[] getKey() {
+        return this.key;
+    }
+}

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MultisigPrivateKeys.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/MultisigPrivateKeys.java
@@ -33,6 +33,10 @@ public class MultisigPrivateKeys extends MigrationAccountKey<String[]> {
         this.key = multipleKey;
     }
 
+    /**
+     * Get multiple private keys of account to be migrated to KAS Wallet.
+     * @return String[] Multiple private key.
+     */
     @Override
     public String[] getKey() {
         return this.key;

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/RoleBasedPrivateKeys.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/RoleBasedPrivateKeys.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 The caver-java-ext-kas Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.groundx.caver_ext_kas.kas.wallet.migration;
+
+import java.util.List;
+
+/**
+ * RoleBasedPrivateKeys presents a set of private keys of role based account type.
+ */
+public class RoleBasedPrivateKeys extends MigrationAccountKey<List<String[]>> {
+    List<String[]> key;
+
+    public RoleBasedPrivateKeys(List<String[]> roleBasedKey) {
+        this.key = roleBasedKey;
+    }
+
+    @Override
+    public List<String[]> getKey() {
+        return this.key;
+    }
+}

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/RoleBasedPrivateKeys.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/RoleBasedPrivateKeys.java
@@ -35,6 +35,10 @@ public class RoleBasedPrivateKeys extends MigrationAccountKey<List<String[]>> {
         this.key = roleBasedKey;
     }
 
+    /**
+     * Get a list of multiple private keys of account to be migrated to KAS Wallet.
+     * @return {@code List<String[]>} A list of multiple private key.
+     */
     @Override
     public List<String[]> getKey() {
         return this.key;

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/RoleBasedPrivateKeys.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/RoleBasedPrivateKeys.java
@@ -19,11 +19,18 @@ package xyz.groundx.caver_ext_kas.kas.wallet.migration;
 import java.util.List;
 
 /**
- * RoleBasedPrivateKeys presents a set of private keys of role based account type.
+ * RoleBasedPrivateKeys presents a list of multiple private keys for role based account type.
  */
 public class RoleBasedPrivateKeys extends MigrationAccountKey<List<String[]>> {
+    /**
+     * A list of multiple private keys of external Klaytn account to be migrated to KAS Wallet.
+     */
     List<String[]> key;
 
+    /**
+     * Create a RoleBasedPrivateKeys instance which will be used as member variable of MigrationAccount.
+     * @param roleBasedKey A list of multiple private keys of external Klaytn account to be migrated to KAS Wallet.
+     */
     public RoleBasedPrivateKeys(List<String[]> roleBasedKey) {
         this.key = roleBasedKey;
     }

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/SinglePrivateKey.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/SinglePrivateKey.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 The caver-java-ext-kas Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xyz.groundx.caver_ext_kas.kas.wallet.migration;
+
+/**
+ * SinglePrivateKey presents a single private key such as account types of a legacy key or public key.
+ */
+public class SinglePrivateKey extends MigrationAccountKey<String> {
+    String key;
+
+    public SinglePrivateKey(String key) {
+        this.key = key;
+    }
+
+    @Override
+    public String getKey() {
+        return this.key;
+    }
+}

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/SinglePrivateKey.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/SinglePrivateKey.java
@@ -33,6 +33,10 @@ public class SinglePrivateKey extends MigrationAccountKey<String> {
         this.key = key;
     }
 
+    /**
+     * Get a list of multiple private keys of account to be migrated to KAS Wallet.
+     * @return String A private key.
+     */
     @Override
     public String getKey() {
         return this.key;

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/SinglePrivateKey.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/migration/SinglePrivateKey.java
@@ -20,8 +20,15 @@ package xyz.groundx.caver_ext_kas.kas.wallet.migration;
  * SinglePrivateKey presents a single private key such as account types of a legacy key or public key.
  */
 public class SinglePrivateKey extends MigrationAccountKey<String> {
+    /**
+     * A private key of external Klaytn account to be migrated to KAS Wallet.
+     */
     String key;
 
+    /**
+     * Create a SinglePrivateKey instance which will be used as member variable of MigrationAccount.
+     * @param key A private key of external Klaytn account to be migrated to KAS Wallet.
+     */
     public SinglePrivateKey(String key) {
         this.key = key;
     }

--- a/src/test/java/xyz/groundx/caver_ext_kas/Config.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/Config.java
@@ -63,8 +63,8 @@ public class Config {
 
     public static final String CHAIN_ID_BAOBOB = "1001";
 
-    public static String accessKey = "";
-    public static String secretAccessKey = "";
+    static String accessKey = "";
+    static String secretAccessKey = "";
 
     public static String feePayerAddress = "";
     public static String operatorAddress = "";
@@ -380,5 +380,13 @@ public class Config {
         } else {
             return TokenHistoryTestData.loadProdData();
         }
+    }
+
+    public static String getAccessKey() {
+        return accessKey;
+    }
+
+    public static String getSecretAccessKey() {
+        return secretAccessKey;
     }
 }

--- a/src/test/java/xyz/groundx/caver_ext_kas/Config.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/Config.java
@@ -63,8 +63,8 @@ public class Config {
 
     public static final String CHAIN_ID_BAOBOB = "1001";
 
-    static String accessKey = "";
-    static String secretAccessKey = "";
+    public static String accessKey = "";
+    public static String secretAccessKey = "";
 
     public static String feePayerAddress = "";
     public static String operatorAddress = "";

--- a/src/test/java/xyz/groundx/caver_ext_kas/wallet/KASWalletIntegrationTest.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/wallet/KASWalletIntegrationTest.java
@@ -109,8 +109,8 @@ public class KASWalletIntegrationTest {
 
             MigrationAccount migrationAccount = new MigrationAccount(
                     singleKeyring.getAddress(),
-                    "0x0",
-                    singleKeyring.getKey().getPrivateKey()
+                    singleKeyring.getKey().getPrivateKey(),
+                    "0x0"
             );
 
             accountsToBeMigrated.add(migrationAccount);

--- a/src/test/java/xyz/groundx/caver_ext_kas/wallet/KASWalletIntegrationTest.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/wallet/KASWalletIntegrationTest.java
@@ -275,28 +275,6 @@ public class KASWalletIntegrationTest {
                     response.getStatus()
             );
         }
-
-        @Test
-        public void migrateMultipleKeyAccount() throws IOException, ApiException, NoSuchFieldException {
-            ArrayList<MigrationAccount> accountsToBeMigrated = new ArrayList<>();
-
-            String address = "0xB8276c915a67BCA98AF8b6b358012E787641Effa";
-            String[] multipleKey = {
-                    "0xb0b488beaccafb159412dce66eb7a5081c10dae05ac81a9e0888fabf963537bf",
-                    "0x4c19be4ce36a222e17978dbf041c6e8359b3f4ce6fc37ae3aae4a7cc14feb1f9",
-                    "0xa6b432c07360bfbff8db0e4c8f5a19ea1168981e72b54d060d345dc652408f4b"
-            };
-
-            MigrationAccount migrationAccount = new MigrationAccount.Builder()
-                    .setAddress(address)
-                    .setMigrationAccountKey(new MultisigPrivateKeys(multipleKey))
-                    .build();
-
-            accountsToBeMigrated.add(migrationAccount);
-
-            RegistrationStatusResponse response = caver.kas.wallet.migrateAccounts(accountsToBeMigrated);
-            assertEquals("Migrating multiple accounts having single key should be succeeded.", "ok", response.getStatus());
-        }
     }
 
     public static class getAccountTest {

--- a/src/test/java/xyz/groundx/caver_ext_kas/wallet/KASWalletIntegrationTest.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/wallet/KASWalletIntegrationTest.java
@@ -25,7 +25,10 @@ import com.klaytn.caver.kct.kip7.KIP7;
 import com.klaytn.caver.methods.response.TransactionReceipt;
 import com.klaytn.caver.transaction.type.*;
 import com.klaytn.caver.utils.Utils;
-import com.klaytn.caver.wallet.keyring.*;
+import com.klaytn.caver.wallet.keyring.KeyringFactory;
+import com.klaytn.caver.wallet.keyring.PrivateKey;
+import com.klaytn.caver.wallet.keyring.SignatureData;
+import com.klaytn.caver.wallet.keyring.SingleKeyring;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -184,7 +187,7 @@ public class KASWalletIntegrationTest {
         }
 
         @Test
-        public void migrateMultipleSingleKeyAccounts_ThrowException_PartiallyFailed() throws ApiException, IOException, NoSuchFieldException {
+        public void migrateMultipleSingleKeyAccounts_throwException_PartiallyFailed() throws ApiException, IOException, NoSuchFieldException {
             ArrayList<MigrationAccount> accountsToBeMigrated = new ArrayList<>();
 
             for (int i=0; i<3; i++) {
@@ -293,6 +296,55 @@ public class KASWalletIntegrationTest {
                     "ok",
                     response.getStatus()
             );
+        }
+
+        @Test
+        public void migrateAccount_throwException_emptyAddress() throws IOException, NoSuchFieldException, ApiException {
+            ArrayList<MigrationAccount> accountsToBeMigrated = new ArrayList<>();
+
+            SingleKeyring singleKeyring = KeyringFactory.generate();
+
+            MigrationAccount migrationAccount = new MigrationAccount(
+                    "",
+                    singleKeyring.getKey().getPrivateKey()
+            );
+
+            accountsToBeMigrated.add(0, migrationAccount);
+
+            try {
+                caver.kas.wallet.migrateAccounts(accountsToBeMigrated);
+            } catch (IllegalArgumentException e) {
+                assertEquals(
+                        "migrating account with empty address should throws exception",
+                        "Given MigrationAccount is not valid.",
+                        e.getMessage()
+                );
+            }
+        }
+
+        @Test
+        public void migrateAccount_throwException_nullKey() throws IOException, NoSuchFieldException, ApiException {
+            ArrayList<MigrationAccount> accountsToBeMigrated = new ArrayList<>();
+
+            SingleKeyring singleKeyring = KeyringFactory.generate();
+
+            MigrationAccount migrationAccount = new MigrationAccount(
+                    singleKeyring.getAddress(),
+                    singleKeyring.getKey().getPrivateKey()
+            );
+            migrationAccount.setMigrationAccountKey(null);
+
+            accountsToBeMigrated.add(0, migrationAccount);
+
+            try {
+                caver.kas.wallet.migrateAccounts(accountsToBeMigrated);
+            } catch (IllegalArgumentException e) {
+                assertEquals(
+                        "migrating account with null key should throws exception",
+                        "Given MigrationAccount is not valid.",
+                        e.getMessage()
+                );
+            }
         }
     }
 

--- a/src/test/java/xyz/groundx/caver_ext_kas/wallet/KASWalletIntegrationTest.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/wallet/KASWalletIntegrationTest.java
@@ -159,6 +159,31 @@ public class KASWalletIntegrationTest {
         }
 
         @Test
+        public void migrateMultipleSingleKeyAccountsUsingValidNonce() throws ApiException, IOException, NoSuchFieldException {
+            ArrayList<MigrationAccount> accountsToBeMigrated = new ArrayList<>();
+            SingleKeyring keyring1 = KeyringFactory.generate();
+            SingleKeyring keyring2 = KeyringFactory.generate();
+
+            // You can set the nonce value to either a hexadecimal string or a BigInteger.
+            accountsToBeMigrated.add(
+                    new MigrationAccount(
+                            keyring1.getAddress(),
+                            keyring1.getKey().getPrivateKey(),
+                            "0x0")
+            );
+            accountsToBeMigrated.add(
+                    new MigrationAccount(
+                            keyring2.getAddress(),
+                            keyring2.getKey().getPrivateKey(),
+                            BigInteger.valueOf(0)
+                    )
+            );
+
+            RegistrationStatusResponse response = caver.kas.wallet.migrateAccounts(accountsToBeMigrated);
+            assertEquals("Migrating an account having single key should be succeeded.", "ok", response.getStatus());
+        }
+
+        @Test
         public void migrateMultipleSingleKeyAccounts_ThrowException_PartiallyFailed() throws ApiException, IOException, NoSuchFieldException {
             ArrayList<MigrationAccount> accountsToBeMigrated = new ArrayList<>();
 

--- a/src/test/java/xyz/groundx/caver_ext_kas/wallet/KASWalletIntegrationTest.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/wallet/KASWalletIntegrationTest.java
@@ -39,8 +39,6 @@ import xyz.groundx.caver_ext_kas.CaverExtKAS;
 import xyz.groundx.caver_ext_kas.Config;
 import xyz.groundx.caver_ext_kas.exception.KASAPIException;
 import xyz.groundx.caver_ext_kas.kas.wallet.migration.MigrationAccount;
-import xyz.groundx.caver_ext_kas.kas.wallet.migration.MultisigPrivateKeys;
-import xyz.groundx.caver_ext_kas.kas.wallet.migration.SinglePrivateKey;
 import xyz.groundx.caver_ext_kas.rest_client.io.swagger.client.ApiException;
 import xyz.groundx.caver_ext_kas.rest_client.io.swagger.client.api.wallet.model.Account;
 import xyz.groundx.caver_ext_kas.rest_client.io.swagger.client.api.wallet.model.AccountSummary;
@@ -94,11 +92,10 @@ public class KASWalletIntegrationTest {
             ArrayList<MigrationAccount> accountsToBeMigrated = new ArrayList<>();
             SingleKeyring singleKeyring = KeyringFactory.generate();
 
-            MigrationAccount migrationAccount = new MigrationAccount.Builder()
-                    .setAddress(singleKeyring.getAddress())
-                    .setMigrationAccountKey(new SinglePrivateKey(singleKeyring.getKey().getPrivateKey()))
-                    .build();
-
+            MigrationAccount migrationAccount = new MigrationAccount(
+                    singleKeyring.getAddress(),
+                    singleKeyring.getKey().getPrivateKey()
+            );
             accountsToBeMigrated.add(migrationAccount);
 
             RegistrationStatusResponse response = caver.kas.wallet.migrateAccounts(accountsToBeMigrated);
@@ -110,11 +107,11 @@ public class KASWalletIntegrationTest {
             ArrayList<MigrationAccount> accountsToBeMigrated = new ArrayList<>();
             SingleKeyring singleKeyring = KeyringFactory.generate();
 
-            MigrationAccount migrationAccount = new MigrationAccount.Builder()
-                    .setAddress(singleKeyring.getAddress())
-                    .setMigrationAccountKey(new SinglePrivateKey(singleKeyring.getKey().getPrivateKey()))
-                    .setNonce(BigInteger.valueOf(0)) // nonce of newly created account is always 0
-                    .build();
+            MigrationAccount migrationAccount = new MigrationAccount(
+                    singleKeyring.getAddress(),
+                    "0x0",
+                    singleKeyring.getKey().getPrivateKey()
+            );
 
             accountsToBeMigrated.add(migrationAccount);
 
@@ -126,11 +123,10 @@ public class KASWalletIntegrationTest {
         public void migrateSingleKeyAccount_ThrowException_AllFailed() throws ApiException, IOException, NoSuchFieldException {
             ArrayList<MigrationAccount> accountsToBeMigrated = new ArrayList<>();
 
-            MigrationAccount accountNotYetDecoupled = new MigrationAccount.Builder()
-                    .setAddress(KeyringFactory.generate().getAddress())
-                    .setMigrationAccountKey(new SinglePrivateKey(PrivateKey.generate().getPrivateKey()))
-                    .build();
-
+            MigrationAccount accountNotYetDecoupled = new MigrationAccount(
+                    KeyringFactory.generate().getAddress(),
+                    PrivateKey.generate().getPrivateKey()
+            );
             accountsToBeMigrated.add(accountNotYetDecoupled);
 
             try {
@@ -151,11 +147,10 @@ public class KASWalletIntegrationTest {
             for (int i=0; i<3; i++) {
                 SingleKeyring singleKeyring = KeyringFactory.generate();
 
-                MigrationAccount migrationAccount = new MigrationAccount.Builder()
-                        .setAddress(singleKeyring.getAddress())
-                        .setMigrationAccountKey(new SinglePrivateKey(singleKeyring.getKey().getPrivateKey()))
-                        .build();
-
+                MigrationAccount migrationAccount = new MigrationAccount(
+                        singleKeyring.getAddress(),
+                        singleKeyring.getKey().getPrivateKey()
+                );
                 accountsToBeMigrated.add(migrationAccount);
             }
 
@@ -170,20 +165,20 @@ public class KASWalletIntegrationTest {
             for (int i=0; i<3; i++) {
                 SingleKeyring singleKeyring = KeyringFactory.generate();
 
-                MigrationAccount migrationAccount = new MigrationAccount.Builder()
-                        .setAddress(singleKeyring.getAddress())
-                        .setMigrationAccountKey(new SinglePrivateKey(singleKeyring.getKey().getPrivateKey()))
-                        .build();
+                MigrationAccount migrationAccount = new MigrationAccount(
+                        singleKeyring.getAddress(),
+                        singleKeyring.getKey().getPrivateKey()
+                );
 
                 accountsToBeMigrated.add(0, migrationAccount);
             }
 
             // Newly created account have a AccountKeyLegacy which means coupled-key in default.
             // Below will be failed to be migrated because it does not use coupled-key.
-            MigrationAccount accountNotYetDecoupled = new MigrationAccount.Builder()
-                    .setAddress(KeyringFactory.generate().getAddress())
-                    .setMigrationAccountKey(new SinglePrivateKey(PrivateKey.generate().getPrivateKey()))
-                    .build();
+            MigrationAccount accountNotYetDecoupled = new MigrationAccount(
+                    KeyringFactory.generate().getAddress(),
+                    PrivateKey.generate().getPrivateKey()
+            );
             accountsToBeMigrated.add(accountNotYetDecoupled);
 
             try {
@@ -205,10 +200,11 @@ public class KASWalletIntegrationTest {
             ArrayList<MigrationAccount> accountsToBeMigrated = new ArrayList<>();
 
             SingleKeyring singleKeyring = KeyringFactory.generate();
-            MigrationAccount migrationAccount = new MigrationAccount.Builder()
-                    .setAddress(singleKeyring.getAddress())
-                    .setMigrationAccountKey(new SinglePrivateKey(singleKeyring.getKey().getPrivateKey()))
-                    .build();
+
+            MigrationAccount migrationAccount = new MigrationAccount(
+                    singleKeyring.getAddress(),
+                    singleKeyring.getKey().getPrivateKey()
+            );
 
             accountsToBeMigrated.add(migrationAccount);
 
@@ -234,11 +230,10 @@ public class KASWalletIntegrationTest {
             for (int i=0; i<2; i++) {
                 SingleKeyring singleKeyring = KeyringFactory.generate();
 
-                MigrationAccount migrationAccount = new MigrationAccount.Builder()
-                        .setAddress(singleKeyring.getAddress())
-                        .setMigrationAccountKey(new SinglePrivateKey(singleKeyring.getKey().getPrivateKey()))
-                        .build();
-
+                MigrationAccount migrationAccount = new MigrationAccount(
+                        singleKeyring.getAddress(),
+                        singleKeyring.getKey().getPrivateKey()
+                );
                 accountsToBeMigrated.add(migrationAccount);
             }
 
@@ -260,11 +255,10 @@ public class KASWalletIntegrationTest {
             for (int i=0; i<2; i++) {
                 SingleKeyring singleKeyring = KeyringFactory.generate();
 
-                MigrationAccount migrationAccount = new MigrationAccount.Builder()
-                        .setAddress(singleKeyring.getAddress())
-                        .setMigrationAccountKey(new SinglePrivateKey(singleKeyring.getKey().getPrivateKey()))
-                        .build();
-
+                MigrationAccount migrationAccount = new MigrationAccount(
+                        singleKeyring.getAddress(),
+                        singleKeyring.getKey().getPrivateKey()
+                );
                 accountsToBeMigrated.add(migrationAccount);
             }
 

--- a/src/test/java/xyz/groundx/caver_ext_kas/wallet/KASWalletIntegrationTest.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/wallet/KASWalletIntegrationTest.java
@@ -221,7 +221,7 @@ public class KASWalletIntegrationTest {
         }
 
         @Test
-        public void migrate_throwException_withoutInitializingNodeAPI() throws ApiException, NoSuchFieldException {
+        public void migrate_throwException_withoutInitializingNodeAPI() throws ApiException, NoSuchFieldException, IOException {
             CaverExtKAS caverExtKAS = new CaverExtKAS();
             caverExtKAS.initWalletAPI(Config.CHAIN_ID_BAOBOB, Config.getAccessKey(), Config.getSecretAccessKey(), Config.URL_WALLET_API);
 
@@ -239,11 +239,11 @@ public class KASWalletIntegrationTest {
             try {
                 // Without initializing Node API, endpoint url of caverExtKAS.rpc is Caver.DEFAULT_URL which is "localhost".
                 caverExtKAS.wallet.walletAPI.migrateAccounts(accountsToBeMigrated);
-            } catch (IOException e) {
+            } catch (RuntimeException e) {
                 assertEquals(
                         "Using account migration feature without init node api should be failed.",
-                        "Connection refused (Connection refused)",
-                        e.getCause().getMessage()
+                        "You should initialize Node API with working endpoint url before calling migrateAccounts.",
+                        e.getMessage()
                 );
             }
         }
@@ -316,7 +316,7 @@ public class KASWalletIntegrationTest {
             } catch (IllegalArgumentException e) {
                 assertEquals(
                         "migrating account with empty address should throws exception",
-                        "Given MigrationAccount is not valid.",
+                        "Address of migrationAccount must not be empty.",
                         e.getMessage()
                 );
             }
@@ -335,13 +335,12 @@ public class KASWalletIntegrationTest {
             migrationAccount.setMigrationAccountKey(null);
 
             accountsToBeMigrated.add(0, migrationAccount);
-
             try {
                 caver.kas.wallet.migrateAccounts(accountsToBeMigrated);
             } catch (IllegalArgumentException e) {
                 assertEquals(
                         "migrating account with null key should throws exception",
-                        "Given MigrationAccount is not valid.",
+                        "MigrationAccountKey of migrationAccount must not be empty.",
                         e.getMessage()
                 );
             }

--- a/src/test/java/xyz/groundx/caver_ext_kas/wallet/KASWalletTest.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/wallet/KASWalletTest.java
@@ -90,14 +90,14 @@ public class KASWalletTest {
             ArrayList<MigrationAccount> accountsToBeMigrated = new ArrayList<>();
 
             String address = KeyringFactory.generate().getAddress();
-            String[] multipleKey = KeyringFactory.generateMultipleKeys(3);
+            String[] multisigPrivateKeys = KeyringFactory.generateMultipleKeys(3);
 
-            MigrationAccount accountWithMultipleKey = new MigrationAccount.Builder()
-                    .setAddress(address)
-                    .setMigrationAccountKey(new MultisigPrivateKeys(multipleKey))
-                    .build();
+            MigrationAccount accountWithMultisigPrivateKeys = new MigrationAccount(
+                    address,
+                    multisigPrivateKeys
+            );
 
-            accountsToBeMigrated.add(accountWithMultipleKey);
+            accountsToBeMigrated.add(accountWithMultisigPrivateKeys);
 
             try {
                 when(wallet.migrateAccounts(accountsToBeMigrated)).thenReturn(response);
@@ -117,14 +117,13 @@ public class KASWalletTest {
             ArrayList<MigrationAccount> accountsToBeMigrated = new ArrayList<>();
 
             String address = KeyringFactory.generate().getAddress();
-            List<String[]> roleBasedKey = KeyringFactory.generateRoleBasedKeys(new int[]{4, 5, 6}, "entropy");
+            List<String[]> roleBasedPrivateKeys = KeyringFactory.generateRoleBasedKeys(new int[]{4, 5, 6}, "entropy");
 
-            MigrationAccount accountWithRoleBasedKey = new MigrationAccount.Builder()
-                    .setAddress(address)
-                    .setMigrationAccountKey(new RoleBasedPrivateKeys(roleBasedKey))
-                    .build();
-
-            accountsToBeMigrated.add(accountWithRoleBasedKey);
+            MigrationAccount accountWithRoleBasedPrivateKeys = new MigrationAccount(
+                    address,
+                    roleBasedPrivateKeys
+            );
+            accountsToBeMigrated.add(accountWithRoleBasedPrivateKeys);
 
             try {
                 when(wallet.migrateAccounts(accountsToBeMigrated)).thenReturn(response);

--- a/src/test/java/xyz/groundx/caver_ext_kas/wallet/KASWalletTest.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/wallet/KASWalletTest.java
@@ -35,6 +35,7 @@ import xyz.groundx.caver_ext_kas.CaverExtKAS;
 import xyz.groundx.caver_ext_kas.Config;
 import xyz.groundx.caver_ext_kas.exception.KASAPIException;
 import xyz.groundx.caver_ext_kas.kas.wallet.Wallet;
+import xyz.groundx.caver_ext_kas.kas.wallet.migration.*;
 import xyz.groundx.caver_ext_kas.rest_client.io.swagger.client.ApiException;
 import xyz.groundx.caver_ext_kas.rest_client.io.swagger.client.api.wallet.model.*;
 
@@ -84,13 +85,17 @@ public class KASWalletTest {
         }
 
         @Test
-        public void migrateMultipleKeyAccount() {
+        public void migrateMultipleKeyAccount() throws NoSuchFieldException {
             Wallet wallet = mock(Wallet.class);
-            ArrayList<AbstractKeyring> accountsToBeMigrated = new ArrayList<>();
+            ArrayList<MigrationAccount> accountsToBeMigrated = new ArrayList<>();
 
             String address = KeyringFactory.generate().getAddress();
             String[] multipleKey = KeyringFactory.generateMultipleKeys(3);
-            MultipleKeyring accountWithMultipleKey = KeyringFactory.createWithMultipleKey(address, multipleKey);
+
+            MigrationAccount accountWithMultipleKey = new MigrationAccount.Builder()
+                    .setAddress(address)
+                    .setMigrationAccountKey(new MultisigPrivateKeys(multipleKey))
+                    .build();
 
             accountsToBeMigrated.add(accountWithMultipleKey);
 
@@ -107,13 +112,17 @@ public class KASWalletTest {
         }
 
         @Test
-        public void migrateRoleBasedKeyAccount() {
+        public void migrateRoleBasedKeyAccount() throws NoSuchFieldException {
             Wallet wallet = mock(Wallet.class);
-            ArrayList<AbstractKeyring> accountsToBeMigrated = new ArrayList<>();
+            ArrayList<MigrationAccount> accountsToBeMigrated = new ArrayList<>();
 
             String address = KeyringFactory.generate().getAddress();
             List<String[]> roleBasedKey = KeyringFactory.generateRoleBasedKeys(new int[]{4, 5, 6}, "entropy");
-            RoleBasedKeyring accountWithRoleBasedKey = KeyringFactory.createWithRoleBasedKey(address, roleBasedKey);
+
+            MigrationAccount accountWithRoleBasedKey = new MigrationAccount.Builder()
+                    .setAddress(address)
+                    .setMigrationAccountKey(new RoleBasedPrivateKeys(roleBasedKey))
+                    .build();
 
             accountsToBeMigrated.add(accountWithRoleBasedKey);
 

--- a/src/test/java/xyz/groundx/caver_ext_kas/wallet/KASWalletTest.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/wallet/KASWalletTest.java
@@ -95,10 +95,10 @@ public class KASWalletTest {
             accountsToBeMigrated.add(accountWithMultipleKey);
 
             try {
-                when(wallet.migrateAccounts(caver.rpc, accountsToBeMigrated)).thenReturn(response);
-                RegistrationStatusResponse actualResponse = wallet.migrateAccounts(caver.rpc, accountsToBeMigrated);
+                when(wallet.migrateAccounts(accountsToBeMigrated)).thenReturn(response);
+                RegistrationStatusResponse actualResponse = wallet.migrateAccounts(accountsToBeMigrated);
 
-                verify(wallet, times(1)).migrateAccounts(caver.rpc, accountsToBeMigrated);
+                verify(wallet, times(1)).migrateAccounts(accountsToBeMigrated);
                 assertEquals("A status of response should be ok", response.getStatus(), actualResponse.getStatus());
             } catch (KASAPIException | IOException | ApiException e) {
                 e.printStackTrace();
@@ -118,10 +118,10 @@ public class KASWalletTest {
             accountsToBeMigrated.add(accountWithRoleBasedKey);
 
             try {
-                when(wallet.migrateAccounts(caver.rpc, accountsToBeMigrated)).thenReturn(response);
-                RegistrationStatusResponse actualResponse = wallet.migrateAccounts(caver.rpc, accountsToBeMigrated);
+                when(wallet.migrateAccounts(accountsToBeMigrated)).thenReturn(response);
+                RegistrationStatusResponse actualResponse = wallet.migrateAccounts(accountsToBeMigrated);
 
-                verify(wallet, times(1)).migrateAccounts(caver.rpc, accountsToBeMigrated);
+                verify(wallet, times(1)).migrateAccounts(accountsToBeMigrated);
                 assertEquals("A status of response should be ok", response.getStatus(), actualResponse.getStatus());
             } catch (KASAPIException | IOException | ApiException e) {
                 e.printStackTrace();


### PR DESCRIPTION
## Proposed changes

This PR added migrateAccounts feature. 
`migrateAccounts` migrates external Klaytn accounts into KAS wallet.

There are a few things you should know about this PR. It would be good to discuss the following.

### point 1: Passing a RPC instance as one of parameter
Unlike [caver-js-ext-kas](https://github.com/ground-x/caver-js-ext-kas) (= one of the KAS SDK implementation using Javascript), I added RPC instance as a parameter.
> function definition of migrateAccounts caver-js is [migrateAccounts(accounts)](https://github.com/ground-x/caver-js-ext-kas/blob/4cb4889748cea306c9b2795c33364a0e680a28e6/src/kas/wallet/wallet.js#L297)

To migrate accounts to KAS Wallet, we need to know nonce of accounts and a gas price of connected Klaytn network.
To fetch nonce for accounts and a gas price, we need to use **“Klay RPC call”** with working Node API endpoint.

What does the above mean is that even if the Node API is initialized after the Wallet API is initialized, 
the Wallet API **_must know the changed endpoint url of the Node API_**.

So in this situation if we do not use RPC instance as parameter,
**1. We should add RPC instance as a member variable of Wallet.**
**2. We should add codes tracking any changes of Node API and updating right away Wallet API to make Wallet API knows changed endpoint url of Node API**

I think the above changes are very inefficient because `migrateAccounts()` method is the only method which requires Node API in the Wallet class.

### Discussion result about point 1 (Applied to this PR)
* Should use same function definition with `caver-js-ext-kas`
* For this, we should add RPC as a member variable of Wallet

### point 2: Mocking tests about migrateAccounts
I Added some test cases that require additional API calls other than those required for account migration as mocking tests.

e.g migration of accounts having **“MultiSig Key”** or **“RoleBased Key”**.
Testing with these type of account requires an additional API call (**Account Update Transaction**).

### point 3: Make accessKeyId and secretAccessKey as public
To intialize each APIs with config, we should make these members as public.
e.g.
```java
caverExtKAS.initWalletAPI(Config.CHAIN_ID_BAOBOB, Config.accessKey, Config.secretAccessKey, Config.URL_WALLET_API);
caverExtKAS.initNodeAPI(Config.CHAIN_ID_BAOBOB, Config.accessKey, Config.secretAccessKey, Config.URL_NODE_API);
```

### Discussion result about point 3 (Applied to this PR)
* acccessKey and secretAccessKey are both secure-sensitive data. so we should encapsulate it.
* So instead of using these member variables as public, we should use getter for these.

```java
caverExtKAS.initWalletAPI(Config.CHAIN_ID_BAOBOB, Config.getAccessKey(), Config.getSecretAccessKey(), Config.URL_WALLET_API);
caverExtKAS.initNodeAPI(Config.CHAIN_ID_BAOBOB, Config.getAccessKey(), Config.getSecretAccessKey(), Config.URL_NODE_API);
```

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-java-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-java-ext-kas)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
