### PR TITLE
Fixed endpoint url only working for PROD env

### DIFF
--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/Wallet.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/Wallet.java
@@ -139,7 +139,7 @@ public class Wallet {
 
         if (this.rpc.getWeb3jService() instanceof HttpService) {
             String url = ((HttpService) this.rpc.getWeb3jService()).getUrl();
-            if (!url.contains("klaytnapi")) {
+            if (!url.contains("klaytn")) {
                 throw new RuntimeException("You should initialize Node API with working endpoint url before calling migrateAccounts.");
             }
         }


### PR DESCRIPTION
## Proposed changes
This PR fixed endpoint url only working for PROD env.

Because QA env and DEV env don't use "klaytnapi" as domain name
When validating endpoint URLs, we should use common domain name "klaytn".

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-java-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-java-ext-kas)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
