### PR TITLE
Removed checking url string before migrating accounts

### DIFF
--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/Wallet.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/Wallet.java
@@ -142,13 +142,6 @@ public class Wallet {
             throw new NoSuchFieldException("Before using migrateAccounts, initNodeAPI must  be called first.");
         }
 
-        if (this.rpc.getWeb3jService() instanceof HttpService) {
-            String url = ((HttpService) this.rpc.getWeb3jService()).getUrl();
-            if (!url.contains("klaytnapi")) {
-                throw new RuntimeException("You should initialize Node API with working endpoint url before calling migrateAccounts.");
-            }
-        }
-
         // Need to validate whether given list of migration accounts is valid or not.
         for (int i=0; i<accountsToBeMigarted.size(); i++) {
             validateMigrationAccount(accountsToBeMigarted.get(i));

--- a/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/Wallet.java
+++ b/src/main/java/xyz/groundx/caver_ext_kas/kas/wallet/Wallet.java
@@ -139,7 +139,7 @@ public class Wallet {
      */
     public RegistrationStatusResponse migrateAccounts(List<MigrationAccount> accountsToBeMigarted) throws ApiException, IOException, NoSuchFieldException {
         if (this.rpc == null) {
-            throw new NoSuchFieldException("Before using migrateAccounts, initNodeAPI must  be called first.");
+            throw new NoSuchFieldException("Before using migrateAccounts, rpc must be set. You should call initNodeAPI first.");
         }
 
         // Need to validate whether given list of migration accounts is valid or not.

--- a/src/test/java/xyz/groundx/caver_ext_kas/kas/wallet/WalletAPITest.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/kas/wallet/WalletAPITest.java
@@ -3237,8 +3237,9 @@ public class WalletAPITest {
 
     @Test
     public void migrate_throwException_withoutInitializingNodeAPI() throws ApiException, NoSuchFieldException, IOException {
-        expectedException.expect(RuntimeException.class);
-        expectedException.expectMessage("You should initialize Node API with working endpoint url before calling migrateAccounts.");
+        // This test case is assuming that the user does not directly launch the KAS service on the local host.
+        // Since it is unlikely that the KAS service will be run on the local host and tested, this test case will be kept as it is.
+        expectedException.expect(java.net.ConnectException.class);
 
         CaverExtKAS caverExtKAS = new CaverExtKAS();
         caverExtKAS.initWalletAPI(Config.CHAIN_ID_BAOBOB, Config.getAccessKey(), Config.getSecretAccessKey(), Config.URL_WALLET_API);


### PR DESCRIPTION
## Proposed changes
This PR suggests removing logic which checks url string of Node API endpoint before migrating accounts.

The original intention of this logic was to notify when the user sets the URL to a service URL other than KAS using the initNodeAPI method, or there is a typo in the entered URL.

However, considering the PROD, QA, and DEV environments, the meaning of this part seems to have faded.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-java-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-java-ext-kas)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
