### PR TITLE
modified a CaverExtKAS class test code.

### DIFF
--- a/src/test/java/xyz/groundx/caver_ext_kas/CaverExtKASTest.java
+++ b/src/test/java/xyz/groundx/caver_ext_kas/CaverExtKASTest.java
@@ -52,18 +52,6 @@ public class CaverExtKASTest {
         assertNotNull(caver.kas.anchor);
         assertNotNull(caver.kas.kip17);
         assertNotNull(caver.kas.kip7);
-
-        options.setUseNodeAPIWithHttp(false);
-        caver = new CaverExtKAS(Config.CHAIN_ID_BAOBOB, Config.getAccessKey(), Config.getSecretAccessKey(), options);
-
-        assertTrue(caver.currentProvider instanceof WebSocketService);
-        assertNotNull(caver.kas.wallet);
-        assertNotNull(caver.kas.tokenHistory);
-        assertNotNull(caver.kas.anchor);
-        assertNotNull(caver.kas.kip17);
-        assertNotNull(caver.kas.kip7);
-
-        caver.currentProvider.close();
     }
 
     @Test
@@ -80,17 +68,5 @@ public class CaverExtKASTest {
         assertNotNull(caver.kas.anchor);
         assertNotNull(caver.kas.kip17);
         assertNotNull(caver.kas.kip7);
-
-        options.setUseNodeAPIWithHttp(false);
-        caver.initKASAPI(Config.CHAIN_ID_BAOBOB, Config.getAccessKey(), Config.getSecretAccessKey(), options);
-
-        assertTrue(caver.currentProvider instanceof WebSocketService);
-        assertNotNull(caver.kas.wallet);
-        assertNotNull(caver.kas.tokenHistory);
-        assertNotNull(caver.kas.anchor);
-        assertNotNull(caver.kas.kip17);
-        assertNotNull(caver.kas.kip7);
-
-        caver.currentProvider.close();
     }
 }


### PR DESCRIPTION
## Proposed changes

This PR modified a CaverExtKAS class test code.
When enabling websocket, CaverExtKAS constructor and initKASAPI() use only production env url, so it didn't correct test case other environment.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-java-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-java-ext-kas)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
